### PR TITLE
Allow for dynamic return sizes from procedures.

### DIFF
--- a/contracts/test/valid/SysCallTest.sol
+++ b/contracts/test/valid/SysCallTest.sol
@@ -52,6 +52,8 @@ contract SysCallTest {
                 mstore(0xd,add(2500,mload(0x80)))
                 revert(0xd,0x20)
             }
+            // On success we simply want to return zero
+            mstore(0x80, 0)
             return(0x80, 0x20)
         }
     }

--- a/contracts/test/valid/SysCallTestCall.sol
+++ b/contracts/test/valid/SysCallTestCall.sol
@@ -5,25 +5,56 @@ contract SysCallTestCall {
     function A() public {
         bytes24 reqProc = bytes24("TestWrite");
         assembly {
+            function malloc(size) -> result {
+                // align to 32-byte words
+                let rsize := add(size,sub(32,mod(size,32)))
+                // get the current free mem location
+                result :=  mload(0x40)
+                // Bump the value of 0x40 so that it holds the next
+                // available memory location.
+                mstore(0x40,add(result,rsize))
+            }
+            function mallocZero(size) -> result {
+                // align to 32-byte words
+                let rsize := add(size,sub(32,mod(size,32)))
+                // get the current free mem location
+                result :=  mload(0x40)
+                // zero-out the memory
+                // if there are some bytes to be allocated (rsize is not zero)
+                if rsize {
+                    // loop through the address and zero them
+                    for { let n := 0 } iszero(eq(n, rsize)) { n := add(n, 32) } {
+                        mstore(add(result,n),0)
+                    }
+                }
+                // Bump the value of 0x40 so that it holds the next
+                // available memory location.
+                mstore(0x40,add(result,rsize))
+            }
+            let inSize := 128
+            let ins := mallocZero(inSize)
             // First set up the input data (at memory location 0x0)
             // The call call is 0x-03
-            mstore(0x0,0x03)
+            mstore(add(ins,0x0),0x03)
             // The capability index is 0x-02
-            mstore(0x20,0x02)
+            mstore(add(ins,0x20),0x02)
             // The key of the procedure
-            mstore(0x40,reqProc)
-            // The size of the return value we expect (0x20)
-            let retSize := 0x20
-            mstore(0x60,retSize)
+            mstore(add(ins,0x40),reqProc)
             // "in_offset" is at 31, because we only want the last byte of type
             // "in_size" is 65 because it is 1+32+32+32
             // we will store the result at 0x80 and it will be 32 bytes
-            if iszero(delegatecall(gas, caller, 31, 97, 0x80, retSize)) {
-                mstore(0xd,add(2200,mload(0x80)))
-                revert(0xd,0x20)
+            if iszero(delegatecall(gas, caller, add(ins,31), 97, 0, 0)) {
+                let retSize := returndatasize
+                let retLoc := malloc(retSize)
+                returndatacopy(retLoc, 0, retSize)
+                mstore(retLoc,add(2200,mload(retLoc)))
+                revert(retLoc,retSize)
             }
-            // mstore(0x80,"hello")
-            return(0x80, retSize)
+            // simply return whatever the system call returned
+            let retSize := returndatasize
+            let retLoc := malloc(retSize)
+            returndatacopy(retLoc, 0, retSize)
+            return(retLoc, retSize)
         }
     }
 
@@ -31,24 +62,56 @@ contract SysCallTestCall {
     function B() public {
         bytes24 reqProc = bytes24("SysCallTest");
         assembly {
+            function malloc(size) -> result {
+                // align to 32-byte words
+                let rsize := add(size,sub(32,mod(size,32)))
+                // get the current free mem location
+                result :=  mload(0x40)
+                // Bump the value of 0x40 so that it holds the next
+                // available memory location.
+                mstore(0x40,add(result,rsize))
+            }
+            function mallocZero(size) -> result {
+                // align to 32-byte words
+                let rsize := add(size,sub(32,mod(size,32)))
+                // get the current free mem location
+                result :=  mload(0x40)
+                // zero-out the memory
+                // if there are some bytes to be allocated (rsize is not zero)
+                if rsize {
+                    // loop through the address and zero them
+                    for { let n := 0 } iszero(eq(n, rsize)) { n := add(n, 32) } {
+                        mstore(add(result,n),0)
+                    }
+                }
+                // Bump the value of 0x40 so that it holds the next
+                // available memory location.
+                mstore(0x40,add(result,rsize))
+            }
+            let inSize := 128
+            let ins := mallocZero(inSize)
             // First set up the input data (at memory location 0x0)
             // The call call is 0x-03
-            mstore(0x0,0x03)
+            mstore(add(ins,0x0),0x03)
             // The capability index is 0x-02
-            mstore(0x20,0x02)
+            mstore(add(ins,0x20),0x02)
             // The key of the procedure
-            mstore(0x40,reqProc)
-            // The size of the return value we expect (0x20)
-            let retSize := 0x20
-            mstore(0x60,retSize)
+            mstore(add(ins,0x40),reqProc)
             // "in_offset" is at 31, because we only want the last byte of type
             // "in_size" is 65 because it is 1+32+32
             // we will store the result at 0x80 and it will be 32 bytes
-            if iszero(delegatecall(gas, caller, 31, 97, 0x80, retSize)) {
-                mstore(0xd,add(2200,mload(0x80)))
-                revert(0xd,0x20)
+            if iszero(delegatecall(gas, caller, add(ins,31), 97, 0, 0)) {
+                let retSize := returndatasize
+                let retLoc := malloc(retSize)
+                returndatacopy(retLoc, 0, retSize)
+                mstore(retLoc,add(2200,mload(retLoc)))
+                revert(retLoc,retSize)
             }
-            return(0x80, retSize)
+            // simply return whatever the system call returned
+            let retSize := returndatasize
+            let retLoc := malloc(retSize)
+            returndatacopy(retLoc, 0, retSize)
+            return(retLoc, retSize)
         }
     }
 
@@ -57,28 +120,56 @@ contract SysCallTestCall {
         bytes24 reqProc = bytes24("SysCallTest");
         string memory fselector = "S()";
         assembly {
+            function malloc(size) -> result {
+                // align to 32-byte words
+                let rsize := add(size,sub(32,mod(size,32)))
+                // get the current free mem location
+                result :=  mload(0x40)
+                // Bump the value of 0x40 so that it holds the next
+                // available memory location.
+                mstore(0x40,add(result,rsize))
+            }
+            function mallocZero(size) -> result {
+                // align to 32-byte words
+                let rsize := add(size,sub(32,mod(size,32)))
+                // get the current free mem location
+                result :=  mload(0x40)
+                // zero-out the memory
+                // if there are some bytes to be allocated (rsize is not zero)
+                if rsize {
+                    // loop through the address and zero them
+                    for { let n := 0 } iszero(eq(n, rsize)) { n := add(n, 32) } {
+                        mstore(add(result,n),0)
+                    }
+                }
+                // Bump the value of 0x40 so that it holds the next
+                // available memory location.
+                mstore(0x40,add(result,rsize))
+            }
+            let inSize := 160
+            let ins := mallocZero(inSize)
             // First set up the input data (at memory location 0x0)
             // The call call is 0x-03
-            mstore(0x0,0x03)
+            mstore(add(ins,0x0),0x03)
             // The capability index is 0x-02
-            mstore(0x20,0x02)
+            mstore(add(ins,0x20),0x02)
             // The key of the procedure
-            mstore(0x40,reqProc)
-            // The size of the return value we expect (0x20)
-            let retSize := 0x20
-            mstore(0x60,retSize)
+            mstore(add(ins,0x40),reqProc)
             // The data from 0x80 onwards is the data we want to send to
             // this procedure
             // First we store the function selector in the 0x20 bytes from 0x60
-            mstore(0x80,keccak256(add(fselector,0x20),mload(fselector)))
+            mstore(add(ins,0x80),keccak256(add(fselector,0x20),mload(fselector)))
             // mstore(0x60,mload(add(fselector,0x20)))
             // we only want the first 4 bytes of this
             // "in_offset" is at 31, because we only want the last byte of type
             // "in_size" is 69 because it is 1+32+32+32+4
             // we will store the result at 0x80 and it will be 32 bytes
-            if iszero(delegatecall(gas, caller, 31, 101, 0x80, retSize)) {
-                mstore(0xd,add(2200,mload(0x80)))
-                revert(0xd,0x20)
+            if iszero(delegatecall(gas, caller, add(ins,31), 101, 0, 0)) {
+                let retSize := returndatasize
+                let retLoc := malloc(retSize)
+                returndatacopy(retLoc, 0, retSize)
+                mstore(retLoc,add(2200,mload(retLoc)))
+                revert(retLoc,retSize)
             }
             // Return nothing in success
             return(0,0)
@@ -90,31 +181,63 @@ contract SysCallTestCall {
         bytes24 reqProc = bytes24("Adder");
         string memory fselector = "add(uint256,uint256)";
         assembly {
+            function malloc(size) -> result {
+                // align to 32-byte words
+                let rsize := add(size,sub(32,mod(size,32)))
+                // get the current free mem location
+                result :=  mload(0x40)
+                // Bump the value of 0x40 so that it holds the next
+                // available memory location.
+                mstore(0x40,add(result,rsize))
+            }
+            function mallocZero(size) -> result {
+                // align to 32-byte words
+                let rsize := add(size,sub(32,mod(size,32)))
+                // get the current free mem location
+                result :=  mload(0x40)
+                // zero-out the memory
+                // if there are some bytes to be allocated (rsize is not zero)
+                if rsize {
+                    // loop through the address and zero them
+                    for { let n := 0 } iszero(eq(n, rsize)) { n := add(n, 32) } {
+                        mstore(add(result,n),0)
+                    }
+                }
+                // Bump the value of 0x40 so that it holds the next
+                // available memory location.
+                mstore(0x40,add(result,rsize))
+            }
+            let inSize := 192
+            let ins := mallocZero(inSize)
             // First set up the input data (at memory location 0x0)
             // The call call is 0x-03
-            mstore(0x0,0x03)
+            mstore(add(ins,0x0),0x03)
             // The capability index is 0x-02
-            mstore(0x20,0x02)
+            mstore(add(ins,0x20),0x02)
             // The key of the procedure
-            mstore(0x40,reqProc)
-            // The size of the return value we expect (0x20)
-            let retSize := 0x20
-            mstore(0x60,retSize)
+            mstore(add(ins,0x40),reqProc)
             // The data from 0x60 onwards is the data we want to send to
             // this procedure
             // First we store the function selector in the 0x20 bytes from 0x60
-            mstore(0x80,keccak256(add(fselector,0x20),mload(fselector)))
-            mstore(0x84,3)
-            mstore(0xa4,5)
+            mstore(add(ins,0x80),keccak256(add(fselector,0x20),mload(fselector)))
+            mstore(add(ins,0x84),3)
+            mstore(add(ins,0xa4),5)
             // we only want the first 4 bytes of this
             // "in_offset" is at 31, because we only want the last byte of type
             // "in_size" is 69 because it is 1+32+32+32+4+32+32
             // we will store the result at 0x80 and it will be 32 bytes
-            if iszero(delegatecall(gas, caller, 31, 165, 0x80, retSize)) {
-                mstore(0xd,add(2200,mload(0x80)))
-                revert(0xd,0x20)
+            if iszero(delegatecall(gas, caller, add(ins,31), 165, 0, 0)) {
+                let retSize := returndatasize
+                let retLoc := malloc(retSize)
+                returndatacopy(retLoc, 0, retSize)
+                mstore(retLoc,add(2200,mload(retLoc)))
+                revert(retLoc,retSize)
             }
-            return(0x80,retSize)
+            // simply return whatever the system call returned
+            let retSize := returndatasize
+            let retLoc := malloc(retSize)
+            returndatacopy(retLoc, 0, retSize)
+            return(retLoc, retSize)
         }
     }
 

--- a/test/withentryproc/syscalls/call.js
+++ b/test/withentryproc/syscalls/call.js
@@ -842,7 +842,9 @@ contract('Kernel with entry procedure', function (accounts) {
                 await kernel.registerProcedure("FifthNestedCall",  deployedFifthNestedContract.address,  beakerlib.Cap.toInput([cap2, new beakerlib.WriteCap(0x8005,0), new beakerlib.CallCap()]));
                 await kernel.registerProcedure("SixthNestedCall",  deployedSixthNestedContract.address,  beakerlib.Cap.toInput([cap2, new beakerlib.WriteCap(0x8006,0), new beakerlib.CallCap()]));
 
-                await kernel.executeProcedure("FirstNestedCall", "G()", "", 32);
+                // TODO: this should be using the entry procedure, no
+                // kernel.executeProcedure
+                await kernel.executeProcedure("FirstNestedCall", "G()", "");
 
                 const firstVal = await kernel.anyTestGetter(0x8001);
                 assert.equal(firstVal.toNumber(),75, `new value should be 75`);

--- a/test/withoutentryproc/procedures.js
+++ b/test/withoutentryproc/procedures.js
@@ -370,7 +370,7 @@ contract('Kernel without entry procedure', function (accounts) {
                 const cap1 = new beakerlib.LogCap([]);
                 const cap2 = new beakerlib.LogCap([0xdeadbeef]);
                 const capArray = beakerlib.Cap.toInput([cap1, cap2]);
-                
+
                 const procedureName = "test";
                 const testAdder = await testutils.deployedTrimmed(Valid.Adder);
 
@@ -390,9 +390,9 @@ contract('Kernel without entry procedure', function (accounts) {
                 await kernel.registerProcedure.call(procedureName, testAdder.address, capArray);
                 await kernel.registerProcedure(procedureName, testAdder.address, capArray);
                 const table3 = await kernel.returnRawProcedureTable.call()
-                
+
                 assert.deepEqual(table1, table3, 'Procedure Tables should be equal')
-                
+
             })
 
             it('removing then registering a superset with same name', async function() {
@@ -404,7 +404,7 @@ contract('Kernel without entry procedure', function (accounts) {
                 const cap2 = new beakerlib.LogCap([0xdeadbeef]);
                 const capArray1 = beakerlib.Cap.toInput([cap1]);
                 const capArray2 = beakerlib.Cap.toInput([cap1, cap2]);
-                
+
                 const procedureName = "test";
                 const testAdder = await testutils.deployedTrimmed(Valid.Adder);
 
@@ -431,7 +431,7 @@ contract('Kernel without entry procedure', function (accounts) {
                  assert.deepEqual(table_sup_new, table_sup, 'Procedure Tables should be equal')
             })
         })
- 
+
         // TODO: this is not currently functional
         it.skip('should destroy the procedures contract on deletion', async function () {
             const kernel = await Kernel.new();
@@ -473,7 +473,7 @@ contract('Kernel without entry procedure', function (accounts) {
     describe('.executeProcedure(bytes24 key, bytes payload)', function () {
         it('should return error if procedure key does not exist(3)', async function () {
             const kernel = await Kernel.new();
-            const retVal = await kernel.executeProcedure.call('test', '', "", 32);
+            const retVal = await kernel.executeProcedure.call('test', '', "");
             assert.equal(retVal, 3);
         });
 
@@ -486,7 +486,7 @@ contract('Kernel without entry procedure', function (accounts) {
                     const tx = await kernel.registerProcedure("Simple", testSimple.address, []);
 
                     // need to have the ABI definition in JSON as per specification
-                    const valueX = await kernel.executeProcedure.call("Simple", "X()", "", 32);
+                    const valueX = await kernel.executeProcedure.call("Simple", "X()", "");
                     assert.equal(valueX.toNumber(), 220000, "X() should fail");
                 })
 
@@ -496,7 +496,7 @@ contract('Kernel without entry procedure', function (accounts) {
                     const [, address] = await kernel.registerProcedure.call("Simple", testSimple.address, []);
                     const tx = await kernel.registerProcedure("Simple", testSimple.address, []);
 
-                    const value1 = await kernel.executeProcedure.call("Simple", "A()", "", 32);
+                    const value1 = await kernel.executeProcedure.call("Simple", "A()", "");
                     assert.equal(value1.toNumber(), 0, "A() should succeed");
                 })
 
@@ -506,7 +506,7 @@ contract('Kernel without entry procedure', function (accounts) {
                     const [, address] = await kernel.registerProcedure.call("Simple", testSimple.address, []);
                     const tx = await kernel.registerProcedure("Simple", testSimple.address, []);
 
-                    const value = await kernel.executeProcedure.call("Simple", "C()", "", 32);
+                    const value = await kernel.executeProcedure.call("Simple", "C()", "");
                     assert.equal(value.toNumber(), 220000, "C() should not succeed");
                 })
 
@@ -516,7 +516,7 @@ contract('Kernel without entry procedure', function (accounts) {
                     const [, address] = await kernel.registerProcedure.call("Simple", testSimple.address, []);
                     const tx = await kernel.registerProcedure("Simple", testSimple.address, []);
 
-                    const value = await kernel.executeProcedure.call("Simple", "C()", "", 32);
+                    const value = await kernel.executeProcedure.call("Simple", "C()", "");
                     assert.equal(value.toNumber(), 220000, "C() should not succeed");
                 })
 
@@ -526,7 +526,7 @@ contract('Kernel without entry procedure', function (accounts) {
                     const [, address] = await kernel.registerProcedure.call("Simple", testSimple.address, []);
                     const tx = await kernel.registerProcedure("Simple", testSimple.address, []);
 
-                    const value = await kernel.executeProcedure.call("Simple", "C(uint256)", "", 32);
+                    const value = await kernel.executeProcedure.call("Simple", "C(uint256)", "");
                     assert.equal(value.toNumber(), 0, "C(uint256) should succeed");
                 })
             })
@@ -591,13 +591,13 @@ contract('Kernel without entry procedure', function (accounts) {
                 // console.log("valueA:", valueA)
 
                 // // need to have the ABI definition in JSON as per specification
-                // const valueX = await kernel.executeProcedure.call("SysCallTest", "S()", "", 32);
-                // await kernel.executeProcedure("SysCallTest", "S()", "", 32);
+                // const valueX = await kernel.executeProcedure.call("SysCallTest", "S()", "");
+                // await kernel.executeProcedure("SysCallTest", "S()", "");
                 // assert.equal(valueX.toNumber(), 4, "S() should succeed with correct value the first time");
 
                 // // do it again
-                // const [err2, value2] = await kernel.executeProcedure.call("SysCallTest", "S()", "", 32);
-                // await kernel.executeProcedure("SysCallTest", "S()", "", 32);
+                // const [err2, value2] = await kernel.executeProcedure.call("SysCallTest", "S()", "");
+                // await kernel.executeProcedure("SysCallTest", "S()", "");
                 // assert.equal(err2.toNumber(), 0, "S() should succeed with zero errcode the second time");
                 // assert.equal(value2.toNumber(), 5, "S() should succeed with correct value the second time");
             })
@@ -605,7 +605,7 @@ contract('Kernel without entry procedure', function (accounts) {
 
         it('should return an error if key does not exist (3)', async function () {
             const kernel = await Kernel.new();
-            const retVal = await kernel.executeProcedure.call('test', '', "", 32);
+            const retVal = await kernel.executeProcedure.call('test', '', "");
             assert.equal(retVal, 3);
         });
 
@@ -642,7 +642,7 @@ contract('Kernel without entry procedure', function (accounts) {
             it('zero length (1)', async function () {
                 const kernel = await Kernel.new();
 
-                const retVal = await kernel.executeProcedure.call('', '', '', 32);
+                const retVal = await kernel.executeProcedure.call('', '', '');
                 assert.equal(retVal.toNumber(), 1);
             });
         })

--- a/test/withoutentryproc/syscalls/call.js
+++ b/test/withoutentryproc/syscalls/call.js
@@ -59,14 +59,14 @@ contract('Kernel without entry procedure', function (accounts) {
                 const originalValue =  await kernel.testGetter.call();
                 assert.equal(originalValue.toNumber(), 3, "test incorrectly set up: initial value should be 3");
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
                 // console.log(web3.toHex(valueX))
                 // try {
                 //     console.log(web3.toAscii(web3.toHex(valueX)))
                 // } catch (e) {
 
                 // }
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 // console.log(tx)
                 // for (const log of tx.receipt.logs) {
                 //     if (log.topics.length > 0) {
@@ -99,8 +99,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const originalValue =  await kernel.testGetter.call();
                 assert.equal(originalValue.toNumber(), 3, "test incorrectly set up: initial value should be 3");
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 222233, "should succeed with zero errcode the first time");
 
                 const newValue =  await kernel.testGetter.call();
@@ -126,8 +126,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const originalValue =  await kernel.testGetter.call();
                 assert.equal(originalValue.toNumber(), 3, "test incorrectly set up: initial value should be 3");
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 222233, "should succeed with zero errcode the first time");
 
                 const newValue =  await kernel.testGetter.call();
@@ -153,8 +153,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const originalValue =  await kernel.testGetter.call();
                 assert.equal(originalValue.toNumber(), 3, "test incorrectly set up: initial value should be 3");
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 0, "should succeed with zero errcode the first time");
 
                 const newValue =  await kernel.testGetter.call();
@@ -180,8 +180,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const originalValue =  await kernel.testGetter.call();
                 assert.equal(originalValue.toNumber(), 3, "test incorrectly set up: initial value should be 3");
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 222233, "should succeed with zero errcode the first time");
 
                 const newValue =  await kernel.testGetter.call();
@@ -214,8 +214,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const originalValue =  await kernel.testGetter.call();
                 assert.equal(originalValue.toNumber(), 3, "test incorrectly set up: initial value should be 3");
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 // console.log(tx.receipt.logs)
                 assert.equal(valueX.toNumber(), 0, "should succeed with zero errcode the first time");
 
@@ -242,8 +242,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const originalValue =  await kernel.testGetter.call();
                 assert.equal(originalValue.toNumber(), 3, "test incorrectly set up: initial value should be 3");
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 222233, "should succeed with zero errcode the first time");
 
                 const newValue =  await kernel.testGetter.call();
@@ -269,8 +269,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const originalValue =  await kernel.testGetter.call();
                 assert.equal(originalValue.toNumber(), 3, "test incorrectly set up: initial value should be 3");
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 222233, "should succeed with zero errcode the first time");
 
                 const newValue =  await kernel.testGetter.call();
@@ -296,8 +296,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const originalValue =  await kernel.testGetter.call();
                 assert.equal(originalValue.toNumber(), 3, "test incorrectly set up: initial value should be 3");
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 0, "should succeed with zero errcode the first time");
 
                 const newValue =  await kernel.testGetter.call();
@@ -323,8 +323,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const originalValue =  await kernel.testGetter.call();
                 assert.equal(originalValue.toNumber(), 3, "test incorrectly set up: initial value should be 3");
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 222233, "should succeed with zero errcode the first time");
 
                 const newValue =  await kernel.testGetter.call();
@@ -356,8 +356,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const originalValue =  await kernel.testGetter.call();
                 assert.equal(originalValue.toNumber(), 3, "test incorrectly set up: initial value should be 3");
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
 
                 assert.equal(valueX.toNumber(), 0, "should succeed with zero errcode the first time");
 
@@ -383,8 +383,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const originalValue =  await kernel.testGetter.call();
                 assert.equal(originalValue.toNumber(), 3, "test incorrectly set up: initial value should be 3");
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 222233, "should succeed with zero errcode the first time");
 
                 const newValue =  await kernel.testGetter.call();
@@ -410,8 +410,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const originalValue =  await kernel.testGetter.call();
                 assert.equal(originalValue.toNumber(), 3, "test incorrectly set up: initial value should be 3");
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 222233, "should succeed with zero errcode the first time");
 
                 const newValue =  await kernel.testGetter.call();
@@ -437,8 +437,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const originalValue =  await kernel.testGetter.call();
                 assert.equal(originalValue.toNumber(), 3, "test incorrectly set up: initial value should be 3");
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 0, "should succeed with zero errcode the first time");
 
                 const newValue =  await kernel.testGetter.call();
@@ -464,8 +464,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const originalValue =  await kernel.testGetter.call();
                 assert.equal(originalValue.toNumber(), 3, "test incorrectly set up: initial value should be 3");
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 222233, "should succeed with zero errcode the first time");
 
                 const newValue =  await kernel.testGetter.call();
@@ -494,8 +494,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 // This is the called procedure
                 const tx2 = await kernel.registerAnyProcedure(testProcName, deployedTestContract.address, beakerlib.Cap.toInput([cap2, cap1]));
 
-                const newValue = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const newValue = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
 
                 assert.equal(newValue.toNumber(),8, `new value should be 8`);
             })
@@ -515,8 +515,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 // This is the called procedure
                 const tx2 = await kernel.registerAnyProcedure(testProcName, deployedTestContract.address, beakerlib.Cap.toInput([cap1]));
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 222233, "should succeed with zero errcode the first time");
             })
             it('E() should fail when given the wrong cap', async function () {
@@ -536,8 +536,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 // This is the called procedure
                 const tx2 = await kernel.registerAnyProcedure(testProcName, deployedTestContract.address, beakerlib.Cap.toInput([cap1]));
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 222233, "should succeed with zero errcode the first time");
             })
             it('E() should succeed with a more restricted cap', async function () {
@@ -557,8 +557,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 // This is the called procedure
                 const tx2 = await kernel.registerAnyProcedure(testProcName, deployedTestContract.address, beakerlib.Cap.toInput([cap2, cap1]));
 
-                const newValue = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const newValue = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(newValue.toNumber(),8, `new value should be 8`);
             })
             it('E() should fail when the given cap is insufficient', async function () {
@@ -578,8 +578,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 // This is the called procedure
                 const tx2 = await kernel.registerAnyProcedure(testProcName, deployedTestContract.address, beakerlib.Cap.toInput([cap1]));
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 222233, "should succeed with zero errcode the first time");
             })
         })
@@ -607,9 +607,9 @@ contract('Kernel without entry procedure', function (accounts) {
                 // // This is the second called procedure, which requires capabilities
                 await kernel.registerProcedure("SysCallTest", deployedSysCallTestContract.address, beakerlib.Cap.toInput([cap2, cap1]));
 
-                const newValue = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
+                const newValue = await kernel.executeProcedure.call(procName, functionSpec, "");
                 // Execute
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 // console.log(tx);
 
                 // console.log(tx.receipt.logs)
@@ -659,7 +659,7 @@ contract('Kernel without entry procedure', function (accounts) {
                 await kernel.registerProcedure("FifthNestedCall",  deployedFifthNestedContract.address,  beakerlib.Cap.toInput([cap2, new beakerlib.WriteCap(0x8005,0), new beakerlib.CallCap()]));
                 await kernel.registerProcedure("SixthNestedCall",  deployedSixthNestedContract.address,  beakerlib.Cap.toInput([cap2, new beakerlib.WriteCap(0x8006,0), new beakerlib.CallCap()]));
 
-                await kernel.executeProcedure("FirstNestedCall", "G()", "", 32);
+                await kernel.executeProcedure("FirstNestedCall", "G()", "");
 
                 const firstVal = await kernel.anyTestGetter(0x8001);
                 assert.equal(firstVal.toNumber(),75, `new value should be 75`);

--- a/test/withoutentryproc/syscalls/log.js
+++ b/test/withoutentryproc/syscalls/log.js
@@ -37,8 +37,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const deployedContract = await testutils.deployedTrimmed(contract);
                 const tx1 = await kernel.registerProcedure(procName, deployedContract.address, capArray);
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
 
                 assert.equal(valueX.toNumber(), 0, "should succeed with zero errcode the first time");
                 assert.equal(tx.receipt.logs[0].data, "0x0000000000000000000000000000000000000000000000000000001234567890", "should succeed with correct value the first time");
@@ -53,8 +53,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const deployedContract = await testutils.deployedTrimmed(contract);
                 const tx0 = await kernel.registerProcedure(procName, deployedContract.address, capArray);
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx1 = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx1 = await kernel.executeProcedure(procName, functionSpec, "");
 
                 assert.equal(valueX.toNumber(), 222233, "errcode should be correct");
                 assert.equal(tx1.receipt.logs.length, 0, "Nothing should be logged");
@@ -70,8 +70,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const tx0 = await kernel.registerProcedure(procName, deployedContract.address, capArray);
 
                 // need to have the ABI definition in JSON as per specification
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx1 = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx1 = await kernel.executeProcedure(procName, functionSpec, "");
                 // 4 is the error code we are after
                 assert.equal(valueX.toNumber(), 222233, "should fail with correct error code");
                 assert.equal(tx1.receipt.logs.length, 0, "Nothing should be logged");
@@ -92,8 +92,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const deployedContract = await testutils.deployedTrimmed(contract);
                 const tx1 = await kernel.registerProcedure(procName, deployedContract.address, capArray);
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 0, "errcode should be correct");
 
                 assert.equal(tx.receipt.logs[0].data, "0x0000000000000000000000000000000000000000000000000000001234567890", "should succeed with correct value the first time");
@@ -110,8 +110,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const deployedContract = await testutils.deployedTrimmed(contract);
                 const tx1 = await kernel.registerProcedure(procName, deployedContract.address, capArray);
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
 
                 assert.equal(valueX.toNumber(), 222233, "errcode should be correct");
                 assert.equal(tx.receipt.logs.length, 0, "Nothing should be logged");
@@ -123,8 +123,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const [, address] = await kernel.registerProcedure.call(procName, deployedContract.address, []);
                 const tx = await kernel.registerProcedure(procName, deployedContract.address, []);
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx1 = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx1 = await kernel.executeProcedure(procName, functionSpec, "");
 
                 assert.equal(valueX.toNumber(), 222233, "errcode should be correct");
                 assert.equal(tx1.receipt.logs.length, 0, "Nothing should be logged");
@@ -140,8 +140,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const tx = await kernel.registerProcedure(procName, deployedContract.address, capArray);
 
                 // need to have the ABI definition in JSON as per specification
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx1 = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx1 = await kernel.executeProcedure(procName, functionSpec, "");
 
                 assert.equal(valueX.toNumber(), 222233, "errcode should be correct");
                 assert.equal(tx1.receipt.logs.length, 0, "Nothing should be logged");
@@ -163,8 +163,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const deployedContract = await testutils.deployedTrimmed(contract);
                 const tx1 = await kernel.registerProcedure(procName, deployedContract.address, capArray);
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 0, "errcode should be correct");
 
                 assert.equal(tx.receipt.logs[0].data, "0x0000000000000000000000000000000000000000000000000000001234567890", "should succeed with correct value the first time");
@@ -178,8 +178,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const [, address] = await kernel.registerProcedure.call(procName, deployedContract.address, []);
                 const tx = await kernel.registerProcedure(procName, deployedContract.address, []);
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx1 = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx1 = await kernel.executeProcedure(procName, functionSpec, "");
 
                 assert.equal(valueX.toNumber(), 222233, "errcode should be correct");
                 assert.equal(tx1.receipt.logs.length, 0, "Nothing should be logged");
@@ -194,8 +194,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const [, address] = await kernel.registerProcedure.call(procName, deployedContract.address, capArray);
                 const tx = await kernel.registerProcedure(procName, deployedContract.address, capArray);
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx1 = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx1 = await kernel.executeProcedure(procName, functionSpec, "");
 
                 assert.equal(valueX.toNumber(), 222233, "errcode should be correct");
                 assert.equal(tx1.receipt.logs.length, 0, "Nothing should be logged");
@@ -218,10 +218,10 @@ contract('Kernel without entry procedure', function (accounts) {
                 const deployedContract = await testutils.deployedTrimmed(contract);
                 const tx1 = await kernel.registerProcedure(procName, deployedContract.address, capArray);
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 0, "errcode should be correct");
- 
+
                 assert.equal(tx.receipt.logs[0].data, "0x0000000000000000000000000000000000000000000000000000001234567890", "should succeed with correct value the first time");
                 assert.equal(tx.receipt.logs[0].topics.length,3,"There should be 3 topics");
                 assert.equal(tx.receipt.logs[0].topics[0],topic0,"The topic0 should be correct");
@@ -235,8 +235,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const [, address] = await kernel.registerProcedure.call(procName, deployedContract.address, []);
                 const tx = await kernel.registerProcedure(procName, deployedContract.address, []);
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx1 = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx1 = await kernel.executeProcedure(procName, functionSpec, "");
 
                 assert.equal(valueX.toNumber(), 222233, "errcode should be correct");
                 assert.equal(tx1.receipt.logs.length, 0, "Nothing should be logged");
@@ -251,8 +251,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const [, address] = await kernel.registerProcedure.call(procName, deployedContract.address, capArray);
                 const tx = await kernel.registerProcedure(procName, deployedContract.address, capArray);
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx1 = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx1 = await kernel.executeProcedure(procName, functionSpec, "");
 
                 assert.equal(valueX.toNumber(), 222233, "errcode should be correct");
                 assert.equal(tx1.receipt.logs.length, 0, "Nothing should be logged");
@@ -276,8 +276,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const deployedContract = await testutils.deployedTrimmed(contract);
                 const tx1 = await kernel.registerProcedure(procName, deployedContract.address, capArray);
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx = await kernel.executeProcedure(procName, functionSpec, "");
                 assert.equal(valueX.toNumber(), 0, "errcode should be correct");
 
                 assert.equal(tx.receipt.logs[0].data, "0x0000000000000000000000000000000000000000000000000000001234567890", "should succeed with correct value the first time");
@@ -294,8 +294,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const [, address] = await kernel.registerProcedure.call(procName, deployedContract.address, []);
                 const tx = await kernel.registerProcedure(procName, deployedContract.address, []);
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx1 = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx1 = await kernel.executeProcedure(procName, functionSpec, "");
 
                 assert.equal(valueX.toNumber(), 222233, "errcode should be correct");
                 assert.equal(tx1.receipt.logs.length, 0, "Nothing should be logged");
@@ -310,8 +310,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const [, address] = await kernel.registerProcedure.call(procName, deployedContract.address, capArray);
                 const tx = await kernel.registerProcedure(procName, deployedContract.address, capArray);
 
-                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "", 32);
-                const tx1 = await kernel.executeProcedure(procName, functionSpec, "", 32);
+                const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
+                const tx1 = await kernel.executeProcedure(procName, functionSpec, "");
 
                 assert.equal(valueX.toNumber(), 222233, "errcode should be correct");
                 assert.equal(tx1.receipt.logs.length, 0, "Nothing should be logged");

--- a/test/withoutentryproc/syscalls/write.js
+++ b/test/withoutentryproc/syscalls/write.js
@@ -38,15 +38,15 @@ contract('Kernel without entry procedure', function (accounts) {
             const newValue1 = await kernel.testGetter.call();
             assert.equal(newValue1.toNumber(), 3, "The value should be 3 before the first execution");
 
-            const valueX = await kernel.executeProcedure.call("SysCallTest", "S()", "", 32);
-            await kernel.executeProcedure("SysCallTest", "S()", "", 32);
+            const valueX = await kernel.executeProcedure.call("SysCallTest", "S()", "");
+            await kernel.executeProcedure("SysCallTest", "S()", "");
             assert.equal(valueX.toNumber(), 0, "S() should succeed with correct value the first time");
             const newValue2 = await kernel.testGetter.call();
             assert.equal(newValue2.toNumber(), 4, "The value should be 4 after the first execution");
 
             // do it again to check that the value has been correctly incremented
-            const value2 = await kernel.executeProcedure.call("SysCallTest", "S()", "", 32);
-            await kernel.executeProcedure("SysCallTest", "S()", "", 32);
+            const value2 = await kernel.executeProcedure.call("SysCallTest", "S()", "");
+            await kernel.executeProcedure("SysCallTest", "S()", "");
             assert.equal(value2.toNumber(), 0, "S() should succeed with correct value the second time");
             const newValue3 = await kernel.testGetter.call();
             assert.equal(newValue3.toNumber(), 5, "The value should be 5 after the second execution");
@@ -59,15 +59,15 @@ contract('Kernel without entry procedure', function (accounts) {
 
             const newValue1 = await kernel.testGetter.call();
             assert.equal(newValue1.toNumber(), 3, "The value should be 3 before the first execution");
-            const valueX = await kernel.executeProcedure.call("SysCallTest", "S()", "", 32);
-            await kernel.executeProcedure("SysCallTest", "S()", "", 32);
+            const valueX = await kernel.executeProcedure.call("SysCallTest", "S()", "");
+            await kernel.executeProcedure("SysCallTest", "S()", "");
             assert.equal(valueX.toNumber(), 222222, "S() should fail with correct value the first time");
             const newValue2 = await kernel.testGetter.call();
             assert.equal(newValue2.toNumber(), 3, "The value should still be 3 before the first execution");
 
             // do it again
-            const value2 = await kernel.executeProcedure.call("SysCallTest", "S()", "", 32);
-            await kernel.executeProcedure("SysCallTest", "S()", "", 32);
+            const value2 = await kernel.executeProcedure.call("SysCallTest", "S()", "");
+            await kernel.executeProcedure("SysCallTest", "S()", "");
             assert.equal(value2.toNumber(), 222222, "S() should succeedfail with correct value the second time");
             const newValue3 = await kernel.testGetter.call();
             assert.equal(newValue3.toNumber(), 3, "The value should still be 3 before the second execution");
@@ -81,15 +81,15 @@ contract('Kernel without entry procedure', function (accounts) {
 
             const newValue1 = await kernel.testGetter.call();
             assert.equal(newValue1.toNumber(), 3, "The value should be 3 before the first execution");
-            const valueX = await kernel.executeProcedure.call("SysCallTest", "S()", "", 32);
-            await kernel.executeProcedure("SysCallTest", "S()", "", 32);
+            const valueX = await kernel.executeProcedure.call("SysCallTest", "S()", "");
+            await kernel.executeProcedure("SysCallTest", "S()", "");
             assert.equal(valueX.toNumber(), 222222, "S() should fail with correct value the first time");
             const newValue2 = await kernel.testGetter.call();
             assert.equal(newValue2.toNumber(), 3, "The value should remain the same the first time");
 
             // do it again
-            const value2 = await kernel.executeProcedure.call("SysCallTest", "S()", "", 32);
-            await kernel.executeProcedure("SysCallTest", "S()", "", 32);
+            const value2 = await kernel.executeProcedure.call("SysCallTest", "S()", "");
+            await kernel.executeProcedure("SysCallTest", "S()", "");
             assert.equal(value2.toNumber(), 222222, "S() should fail with correct value the second time");
             const newValue3 = await kernel.testGetter.call();
             assert.equal(newValue3.toNumber(), 3, "The value should remain the same the second time");


### PR DESCRIPTION
Previously, the expeted return size had to be included with any system calls as the return size needed to be known by the kernel. This commit changes the kernel (and the example procedures) to use  RETURNDATASIZE and RETURNDATACOPY. Using these opcodes, the size of the return data is determined after the call and can be of any size.