### PR TITLE
Move Call Syscall to lib

### DIFF
--- a/contracts/test/valid/NestedCalls/FirstNestedCall.sol
+++ b/contracts/test/valid/NestedCalls/FirstNestedCall.sol
@@ -15,74 +15,15 @@ contract FirstNestedCall is BeakerContract {
         write(1, 0x8001, 75);
 
         // Begin our call to SecondNestedCall
-        bytes24 reqProc = bytes24("SecondNestedCall");
-        string memory fselector = "G()";
-        assembly {
-            function malloc(size) -> result {
-                // align to 32-byte words
-                let rsize := add(size,sub(32,mod(size,32)))
-                // get the current free mem location
-                result :=  mload(0x40)
-                // Bump the value of 0x40 so that it holds the next
-                // available memory location.
-                mstore(0x40,add(result,rsize))
-            }
-            let ins := malloc(128)
-            // First set up the input data (at memory location 0x0)
-            // The call call is 0x-03
-            mstore(add(ins,0x0),0x03)
-            // The capability index is 0x-02
-            mstore(add(ins,0x20),0x02)
-            // The key of the procedure
-            mstore(add(ins,0x40),reqProc)
-            // The size of the return value we expect (0x20)
-            let retSize := 0x20
-            let retLoc := malloc(retSize)
-            mstore(add(ins,0x60),retSize)
-            mstore(add(ins,0x80),keccak256(add(fselector,0x20),mload(fselector)))
-            // "in_offset" is at 31, because we only want the last byte of type
-            // "in_size" is 65 because it is 1+32+32+32+4
-            // we will store the result at 0x80 and it will be 32 bytes
-            if iszero(delegatecall(gas, caller, add(ins,31), 101, retLoc, retSize)) {
-                mstore(0xd,add(2200,mload(retLoc)))
-                revert(0xd,0x20)
-            }
-        }
-        // End procedure call
+        uint32[] memory input = new uint32[](1);
+        input[0] = 0;
+
+        proc_call(2, "SecondNestedCall", "G()", input);
+
         // Being our call to SixthNestedCall
-        reqProc = bytes24("SixthNestedCall");
-        assembly {
-            function malloc(size) -> result {
-                // align to 32-byte words
-                let rsize := add(size,sub(32,mod(size,32)))
-                // get the current free mem location
-                result :=  mload(0x40)
-                // Bump the value of 0x40 so that it holds the next
-                // available memory location.
-                mstore(0x40,add(result,rsize))
-            }
-            let ins := malloc(128)
-            // First set up the input data (at memory location 0x0)
-            // The call call is 0x-03
-            mstore(add(ins,0x0),0x03)
-            // The capability index is 0x-02
-            mstore(add(ins,0x20),0x02)
-            // The key of the procedure
-            mstore(add(ins,0x40),reqProc)
-            // The size of the return value we expect (0x20)
-            let retSize := 0x20
-            let retLoc := malloc(retSize)
-            mstore(add(ins,0x60),retSize)
-            mstore(add(ins,0x80),keccak256(add(fselector,0x20),mload(fselector)))
-            // "in_offset" is at 31, because we only want the last byte of type
-            // "in_size" is 65 because it is 1+32+32+32+4
-            // we will store the result at 0x80 and it will be 32 bytes
-            if iszero(delegatecall(gas, caller, add(ins,31), 101, retLoc, retSize)) {
-                mstore(0xd,add(2200,mload(retLoc)))
-                revert(0xd,0x20)
-            }
-        }
-        // End procedure call
-        // TODO: perform some checks and return
+        uint32[] memory input2 = new uint32[](1);
+        input[0] = 0;
+
+        proc_call(2, "SixthNestedCall", "G()", input2);
     }
 }

--- a/contracts/test/valid/NestedCalls/SecondNestedCall.sol
+++ b/contracts/test/valid/NestedCalls/SecondNestedCall.sol
@@ -17,74 +17,14 @@ contract SecondNestedCall  is BeakerContract {
         write(1, 0x8002, 76);
 
         // Being our call to ThirdNestedCall
-        bytes24 reqProc = bytes24("ThirdNestedCall");
-        string memory fselector = "G()";
-        assembly {
-            function malloc(size) -> result {
-                // align to 32-byte words
-                let rsize := add(size,sub(32,mod(size,32)))
-                // get the current free mem location
-                result :=  mload(0x40)
-                // Bump the value of 0x40 so that it holds the next
-                // available memory location.
-                mstore(0x40,add(result,rsize))
-            }
-            let ins := malloc(128)
-            // First set up the input data (at memory location 0x0)
-            // The call call is 0x-03
-            mstore(add(ins,0x0),0x03)
-            // The capability index is 0x-02
-            mstore(add(ins,0x20),0x02)
-            // The key of the procedure
-            mstore(add(ins,0x40),reqProc)
-            // The size of the return value we expect (0x20)
-            let retSize := 0x20
-            let retLoc := malloc(retSize)
-            mstore(add(ins,0x60),retSize)
-            mstore(add(ins,0x80),keccak256(add(fselector,0x20),mload(fselector)))
-            // "in_offset" is at 31, because we only want the last byte of type
-            // "in_size" is 65 because it is 1+32+32+32+4
-            // we will store the result at 0x80 and it will be 32 bytes
-            if iszero(delegatecall(gas, caller, add(ins,31), 101, retLoc, retSize)) {
-                mstore(0xd,add(2200,mload(0x80)))
-                revert(0xd,0x20)
-            }
-        }
-        // End procedure call
+        uint32[] memory input1 = new uint32[](1);
+        input1[0] = 0;
+
+        proc_call(2, "ThirdNestedCall", "G()", input1);
+
         // Being our call to FifthNestedCall
-        reqProc = bytes24("FifthNestedCall");
-        assembly {
-            function malloc(size) -> result {
-                // align to 32-byte words
-                let rsize := add(size,sub(32,mod(size,32)))
-                // get the current free mem location
-                result :=  mload(0x40)
-                // Bump the value of 0x40 so that it holds the next
-                // available memory location.
-                mstore(0x40,add(result,rsize))
-            }
-            let ins := malloc(128)
-            // First set up the input data (at memory location 0x0)
-            // The call call is 0x-03
-            mstore(add(ins,0x0),0x03)
-            // The capability index is 0x-02
-            mstore(add(ins,0x20),0x02)
-            // The key of the procedure
-            mstore(add(ins,0x40),reqProc)
-            // The size of the return value we expect (0x20)
-            let retSize := 0x20
-            let retLoc := malloc(retSize)
-            mstore(add(ins,0x60),retSize)
-            mstore(add(ins,0x80),keccak256(add(fselector,0x20),mload(fselector)))
-            // "in_offset" is at 31, because we only want the last byte of type
-            // "in_size" is 65 because it is 1+32+32+32+4
-            // we will store the result at 0x80 and it will be 32 bytes
-            if iszero(delegatecall(gas, caller, add(ins,31), 101, retLoc, retSize)) {
-                mstore(0xd,add(2200,mload(0x80)))
-                revert(0xd,0x20)
-            }
-        }
-        // End procedure call
-        // TODO: perform some checks and return
+        uint32[] memory input2 = new uint32[](1);
+        input2[0] = 0;
+        proc_call(2, "FifthNestedCall", "G()", input2);
     }
 }

--- a/contracts/test/valid/NestedCalls/ThirdNestedCall.sol
+++ b/contracts/test/valid/NestedCalls/ThirdNestedCall.sol
@@ -16,40 +16,9 @@ contract ThirdNestedCall  is BeakerContract {
         write(1, 0x8003, 77);
         
         // Being our call to FourthNestedCall
-        bytes24 reqProc = bytes24("FourthNestedCall");
-        string memory fselector = "G()";
-        assembly {
-            function malloc(size) -> result {
-                // align to 32-byte words
-                let rsize := add(size,sub(32,mod(size,32)))
-                // get the current free mem location
-                result :=  mload(0x40)
-                // Bump the value of 0x40 so that it holds the next
-                // available memory location.
-                mstore(0x40,add(result,rsize))
-            }
-            let ins := malloc(128)
-            // First set up the input data (at memory location 0x0)
-            // The call call is 0x-03
-            mstore(add(ins,0x0),0x03)
-            // The capability index is 0x-02
-            mstore(add(ins,0x20),0x02)
-            // The key of the procedure
-            mstore(add(ins,0x40),reqProc)
-            // The size of the return value we expect (0x20)
-            let retSize := 0x20
-            let retLoc := malloc(retSize)
-            mstore(add(ins,0x60),retSize)
-            mstore(add(ins,0x80),keccak256(add(fselector,0x20),mload(fselector)))
-            // "in_offset" is at 31, because we only want the last byte of type
-            // "in_size" is 65 because it is 1+32+32+32+4
-            // we will store the result at 0x80 and it will be 32 bytes
-            if iszero(delegatecall(gas, caller, add(ins,31), 101, retLoc, retSize)) {
-                mstore(0xd,add(2200,mload(0x80)))
-                revert(0xd,0x20)
-            }
-        }
-        // End procedure call
-        // TODO: perform some checks and return
+        uint32[] memory input = new uint32[](1);
+        input[0] = 0;
+
+        proc_call(2, "FourthNestedCall", "G()", input);
     }
 }

--- a/contracts/test/valid/SysCallTestCall.sol
+++ b/contracts/test/valid/SysCallTestCall.sol
@@ -1,343 +1,62 @@
 pragma solidity ^0.4.17;
 
-contract SysCallTestCall {
+import "../../BeakerContract.sol";
+
+contract SysCallTestCall is BeakerContract {
     // Log to no topics
-    function A() public {
-        bytes24 reqProc = bytes24("TestWrite");
-        assembly {
-            function malloc(size) -> result {
-                // align to 32-byte words
-                let rsize := add(size,sub(32,mod(size,32)))
-                // get the current free mem location
-                result :=  mload(0x40)
-                // Bump the value of 0x40 so that it holds the next
-                // available memory location.
-                mstore(0x40,add(result,rsize))
-            }
-            function mallocZero(size) -> result {
-                // align to 32-byte words
-                let rsize := add(size,sub(32,mod(size,32)))
-                // get the current free mem location
-                result :=  mload(0x40)
-                // zero-out the memory
-                // if there are some bytes to be allocated (rsize is not zero)
-                if rsize {
-                    // loop through the address and zero them
-                    for { let n := 0 } iszero(eq(n, rsize)) { n := add(n, 32) } {
-                        mstore(add(result,n),0)
-                    }
-                }
-                // Bump the value of 0x40 so that it holds the next
-                // available memory location.
-                mstore(0x40,add(result,rsize))
-            }
-            let inSize := 128
-            let ins := mallocZero(inSize)
-            // First set up the input data (at memory location 0x0)
-            // The call call is 0x-03
-            mstore(add(ins,0x0),0x03)
-            // The capability index is 0x-02
-            mstore(add(ins,0x20),0x02)
-            // The key of the procedure
-            mstore(add(ins,0x40),reqProc)
-            // "in_offset" is at 31, because we only want the last byte of type
-            // "in_size" is 65 because it is 1+32+32+32
-            // we will store the result at 0x80 and it will be 32 bytes
-            if iszero(delegatecall(gas, caller, add(ins,31), 97, 0, 0)) {
-                let retSize := returndatasize
-                let retLoc := malloc(retSize)
-                returndatacopy(retLoc, 0, retSize)
-                mstore(retLoc,add(2200,mload(retLoc)))
-                revert(retLoc,retSize)
-            }
-            // simply return whatever the system call returned
-            let retSize := returndatasize
-            let retLoc := malloc(retSize)
-            returndatacopy(retLoc, 0, retSize)
-            return(retLoc, retSize)
-        }
+    function A() public returns (uint32) {
+        uint32[] memory input = new uint32[](1);
+        input[0] = 0;
+
+        var (err, output) = proc_call(2, "TestWrite", "", input);
+        return err;
     }
 
     // Call SysCallTestWrite
-    function B() public {
-        bytes24 reqProc = bytes24("SysCallTestWrite");
-        assembly {
-            function malloc(size) -> result {
-                // align to 32-byte words
-                let rsize := add(size,sub(32,mod(size,32)))
-                // get the current free mem location
-                result :=  mload(0x40)
-                // Bump the value of 0x40 so that it holds the next
-                // available memory location.
-                mstore(0x40,add(result,rsize))
-            }
-            function mallocZero(size) -> result {
-                // align to 32-byte words
-                let rsize := add(size,sub(32,mod(size,32)))
-                // get the current free mem location
-                result :=  mload(0x40)
-                // zero-out the memory
-                // if there are some bytes to be allocated (rsize is not zero)
-                if rsize {
-                    // loop through the address and zero them
-                    for { let n := 0 } iszero(eq(n, rsize)) { n := add(n, 32) } {
-                        mstore(add(result,n),0)
-                    }
-                }
-                // Bump the value of 0x40 so that it holds the next
-                // available memory location.
-                mstore(0x40,add(result,rsize))
-            }
-            let inSize := 128
-            let ins := mallocZero(inSize)
-            // First set up the input data (at memory location 0x0)
-            // The call call is 0x-03
-            mstore(add(ins,0x0),0x03)
-            // The capability index is 0x-02
-            mstore(add(ins,0x20),0x02)
-            // The key of the procedure
-            mstore(add(ins,0x40),reqProc)
-            // "in_offset" is at 31, because we only want the last byte of type
-            // "in_size" is 65 because it is 1+32+32
-            // we will store the result at 0x80 and it will be 32 bytes
-            if iszero(delegatecall(gas, caller, add(ins,31), 97, 0, 0)) {
-                let retSize := returndatasize
-                let retLoc := malloc(retSize)
-                returndatacopy(retLoc, 0, retSize)
-                mstore(retLoc,add(2200,mload(retLoc)))
-                revert(retLoc,retSize)
-            }
-            // simply return whatever the system call returned
-            let retSize := returndatasize
-            let retLoc := malloc(retSize)
-            returndatacopy(retLoc, 0, retSize)
-            return(retLoc, retSize)
-        }
+    function B() public returns (uint32) {
+        uint32[] memory input = new uint32[](1);
+        input[0] = 0;
+
+        var (err, output) = proc_call(2, "SysCallTestWrite", "", input);
+        return err;
     }
 
     // Call SysTestCall:S()
     function C() public {
-        bytes24 reqProc = bytes24("SysCallTestWrite");
-        string memory fselector = "S()";
-        assembly {
-            function malloc(size) -> result {
-                // align to 32-byte words
-                let rsize := add(size,sub(32,mod(size,32)))
-                // get the current free mem location
-                result :=  mload(0x40)
-                // Bump the value of 0x40 so that it holds the next
-                // available memory location.
-                mstore(0x40,add(result,rsize))
-            }
-            function mallocZero(size) -> result {
-                // align to 32-byte words
-                let rsize := add(size,sub(32,mod(size,32)))
-                // get the current free mem location
-                result :=  mload(0x40)
-                // zero-out the memory
-                // if there are some bytes to be allocated (rsize is not zero)
-                if rsize {
-                    // loop through the address and zero them
-                    for { let n := 0 } iszero(eq(n, rsize)) { n := add(n, 32) } {
-                        mstore(add(result,n),0)
-                    }
-                }
-                // Bump the value of 0x40 so that it holds the next
-                // available memory location.
-                mstore(0x40,add(result,rsize))
-            }
-            let inSize := 160
-            let ins := mallocZero(inSize)
-            // First set up the input data (at memory location 0x0)
-            // The call call is 0x-03
-            mstore(add(ins,0x0),0x03)
-            // The capability index is 0x-02
-            mstore(add(ins,0x20),0x02)
-            // The key of the procedure
-            mstore(add(ins,0x40),reqProc)
-            // The data from 0x80 onwards is the data we want to send to
-            // this procedure
-            // First we store the function selector in the 0x20 bytes from 0x60
-            mstore(add(ins,0x80),keccak256(add(fselector,0x20),mload(fselector)))
-            // mstore(0x60,mload(add(fselector,0x20)))
-            // we only want the first 4 bytes of this
-            // "in_offset" is at 31, because we only want the last byte of type
-            // "in_size" is 69 because it is 1+32+32+32+4
-            // we will store the result at 0x80 and it will be 32 bytes
-            if iszero(delegatecall(gas, caller, add(ins,31), 101, 0, 0)) {
-                let retSize := returndatasize
-                let retLoc := malloc(retSize)
-                returndatacopy(retLoc, 0, retSize)
-                mstore(retLoc,add(2200,mload(retLoc)))
-                revert(retLoc,retSize)
-            }
-            // Return nothing in success
-            return(0,0)
-        }
+        uint32[] memory input = new uint32[](1);
+        input[0] = 0;
+
+        var (err, output) = proc_call(2, "SysCallTestWrite", "S()", input);
     }
 
     // Call Adder:add(3,5), return result
-    function E() public {
-        bytes24 reqProc = bytes24("Adder");
-        string memory fselector = "add(uint256,uint256)";
-        assembly {
-            function malloc(size) -> result {
-                // align to 32-byte words
-                let rsize := add(size,sub(32,mod(size,32)))
-                // get the current free mem location
-                result :=  mload(0x40)
-                // Bump the value of 0x40 so that it holds the next
-                // available memory location.
-                mstore(0x40,add(result,rsize))
-            }
-            function mallocZero(size) -> result {
-                // align to 32-byte words
-                let rsize := add(size,sub(32,mod(size,32)))
-                // get the current free mem location
-                result :=  mload(0x40)
-                // zero-out the memory
-                // if there are some bytes to be allocated (rsize is not zero)
-                if rsize {
-                    // loop through the address and zero them
-                    for { let n := 0 } iszero(eq(n, rsize)) { n := add(n, 32) } {
-                        mstore(add(result,n),0)
-                    }
-                }
-                // Bump the value of 0x40 so that it holds the next
-                // available memory location.
-                mstore(0x40,add(result,rsize))
-            }
-            let inSize := 192
-            let ins := mallocZero(inSize)
-            // First set up the input data (at memory location 0x0)
-            // The call call is 0x-03
-            mstore(add(ins,0x0),0x03)
-            // The capability index is 0x-02
-            mstore(add(ins,0x20),0x02)
-            // The key of the procedure
-            mstore(add(ins,0x40),reqProc)
-            // The data from 0x60 onwards is the data we want to send to
-            // this procedure
-            // First we store the function selector in the 0x20 bytes from 0x60
-            mstore(add(ins,0x80),keccak256(add(fselector,0x20),mload(fselector)))
-            mstore(add(ins,0x84),3)
-            mstore(add(ins,0xa4),5)
-            // we only want the first 4 bytes of this
-            // "in_offset" is at 31, because we only want the last byte of type
-            // "in_size" is 69 because it is 1+32+32+32+4+32+32
-            // we will store the result at 0x80 and it will be 32 bytes
-            if iszero(delegatecall(gas, caller, add(ins,31), 165, 0, 0)) {
-                let retSize := returndatasize
-                let retLoc := malloc(retSize)
-                returndatacopy(retLoc, 0, retSize)
-                mstore(retLoc,add(2200,mload(retLoc)))
-                revert(retLoc,retSize)
-            }
-            // simply return whatever the system call returned
-            let retSize := returndatasize
-            let retLoc := malloc(retSize)
-            returndatacopy(retLoc, 0, retSize)
-            return(retLoc, retSize)
-        }
+    function E() public returns (uint) {
+
+        uint32[] memory input = new uint32[](2);
+        input[0] = 3;
+        input[1] = 5;
+        
+        var (err, output) = proc_call(2, "Adder", "add(uint256,uint256)", input);
+        
+        return uint256(output[31]);
     }
 
     // Do deeper call stacks
     function F() public returns (uint256) {
-        bytes24 reqProc = bytes24("Adder");
-        string memory fselector = "add(uint256,uint256)";
+
         // We will store the result from the first procedure call (add) here
-        uint256 addResult;
-        assembly {
+        uint32[] memory input = new uint32[](2);
+        input[0] = 3;
+        input[1] = 5;
+        
+        var (err, output) = proc_call(2, "Adder", "add(uint256,uint256)", input);
+        uint256 addResult = uint256(output[31]);
 
-            function malloc(size) -> result {
-                let rsize := add(size,sub(32,mod(size,32)))
-                // get the current free mem location
-                result :=  mload(0x40)
-                // Bump the value of 0x40 so that it holds the next
-                // available memory location.
-                mstore(0x40,add(result,rsize))
-            }
-            // allocate some space for data
-            // "in_offset" is at 31, because we only want the last byte of type
-            // "in_size" is 69 because it is 1+32+32+32+4
-            // we will store the result at 0x80 and it will be 32 bytes
-            let inl := 165
-            let ins := malloc(224)
+        uint32[] memory input2 = new uint32[](1);
+        input[0] = 0;
 
-            // First set up the input data (at memory location 0x0)
-            // The call call is 0x-03
-            mstore(add(ins,0x0),0x03)
-            // The capability index is 0x-02
-            mstore(add(ins,0x20),0x02)
-            // The key of the procedure
-            mstore(add(ins,0x40),reqProc)
-            // The size of the return value we expect (0x20)
-            let retSize := 0x20
-            mstore(add(ins,0x60),retSize)
-            // The data from 0x60 onwards is the data we want to send to
-            // this procedure
-            // First we store the function selector in the 0x20 bytes from 0x60
-            mstore(add(ins,0x80),keccak256(add(fselector,0x20),mload(fselector)))
-            mstore(add(ins,0x84),3)
-            mstore(add(ins,0xa4),5)
-            // we only want the first 4 bytes of this
-            // "in_offset" is at 31, because we only want the last byte of type
-            // "in_size" is 69 because it is 1+32+32+32+4+32+32
-            // we will store the result at 0x80 and it will be 32 bytes
+        proc_call(2, "SysCallTestWrite", "S()", input2);
 
-            let retLoc := malloc(retSize)
-            if iszero(delegatecall(gas, caller, add(ins,31), inl, retLoc, retSize)) {
-                mstore(0xd,add(2200,mload(retLoc)))
-                revert(0xd,0x20)
-            }
-            if iszero(eq(mload(retLoc),8)) {
-                mstore(retLoc,77)
-                revert(retLoc,0x20)
-            }
-            mstore(0x999,mload(retLoc))
-            addResult := mload(retLoc)
-
-        }
-        reqProc = bytes24("SysCallTestWrite");
-        string memory newfselector = "S()";
-        assembly {
-            function malloc(size) -> result {
-                // align to 32-byte words
-                let rsize := add(size,sub(32,mod(size,32)))
-                // get the current free mem location
-                result :=  mload(0x40)
-                // Bump the value of 0x40 so that it holds the next
-                // available memory location.
-                mstore(0x40,add(result,rsize))
-            }
-            // allocate some space for data
-            // "in_offset" is at 31, because we only want the last byte of type
-            // "in_size" is 69 because it is 1+32+32+32+4
-            // we will store the result at 0x80 and it will be 32 bytes
-            let inl := 101
-            let ins := malloc(160)
-
-            // First set up the input data (at memory location 0x0)
-            // The call call is 0x-03
-            mstore(add(ins,0x0),0x03)
-            // The capability index is 0x-02
-            mstore(add(ins,0x20),0x02)
-            // The key of the procedure
-            mstore(add(ins,0x40),reqProc)
-            // The size of the return value we expect (0x20)
-            let retSize := 0x20
-            let retLoc := malloc(retSize)
-            mstore(add(ins,0x60),retSize)
-            mstore(add(ins,0x80),keccak256(add(newfselector,0x20),mload(newfselector)))
-            // we only want the first 4 bytes of this
-            // "in_offset" is at 31, because we only want the last byte of type
-            // "in_size" is 69 because it is 1+32+32+32+4
-            // we will store the result at 0x80 and it will be 32 bytes
-            if iszero(delegatecall(gas, caller, add(ins,31), inl,  retLoc, retSize)) {
-                mstore(0xd,add(2500,mload(retLoc)))
-                revert(0xd,0x20)
-            }
-        }
         return addResult;
     }
 }

--- a/test/withoutentryproc/syscalls/call.js
+++ b/test/withoutentryproc/syscalls/call.js
@@ -356,14 +356,6 @@ contract('Kernel without entry procedure', function (accounts) {
 
                 const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
                 const tx = await kernel.executeProcedure(procName, functionSpec, "");
-                // console.log(tx)
-                // for (const log of tx.receipt.logs) {
-                //     if (log.topics.length > 0) {
-                //         console.log(`Log: ${web3.toAscii(log.topics[0])} - ${log.data} - ${web3.toAscii(log.data)}`);
-                //     } else {
-                //         console.log(`Log: ${log.topics[0]} - ${web3.toAscii(log.data)} - ${log.data}`);
-                //     }
-                // }
                 assert.equal(valueX.toNumber(), 0, "should succeed with zero errcode the first time");
 
                 const newValue =  await kernel.testGetter.call();
@@ -492,8 +484,6 @@ contract('Kernel without entry procedure', function (accounts) {
                 const cap3 = new beakerlib.CallCap();
                 const capArray = beakerlib.Cap.toInput([cap1, cap2, cap3]);
                 
-                kernel.allEvents().watch(console.log)
-
                 const deployedContract = await testutils.deployedTrimmed(contract);
                 const deployedTestContract = await testutils.deployedTrimmed(testContract);
                 // This is the procedure that will do the calling
@@ -503,15 +493,6 @@ contract('Kernel without entry procedure', function (accounts) {
 
                 const newValue = await kernel.executeProcedure.call(procName, functionSpec, "");
                 const tx = await kernel.executeProcedure(procName, functionSpec, "");
-                // console.log(tx)
-                // for (const log of tx.receipt.logs) {
-                //     if (log.topics.length > 0) {
-                //         console.log(`Log: ${web3.toAscii(log.topics[0])} - ${log.data} - ${web3.toAscii(log.data)}`);
-                //     } else {
-                //         console.log(`Log: ${log.topics[0]} - ${log.data}`);
-                //     }
-                // }
-                // console.log(newValue)
                 assert.equal(newValue.toNumber(),8, `new value should be 8`);
             })
             it('E() should fail when not given cap', async function () {

--- a/test/withoutentryproc/syscalls/call.js
+++ b/test/withoutentryproc/syscalls/call.js
@@ -641,7 +641,7 @@ contract('Kernel without entry procedure', function (accounts) {
                 assert.equal(newValue2.toNumber(),4, "new value should be 4");
             })
         })
-        describe.only('G() - deeper stacks', function () {
+        describe('G() - deeper stacks', function () {
             const testProcName = "FirstNestedCall";
             const testBytecode = Valid.FirstNestedCall.bytecode;
             const functionSpec = "G()";

--- a/test/withoutentryproc/syscalls/call.js
+++ b/test/withoutentryproc/syscalls/call.js
@@ -356,7 +356,14 @@ contract('Kernel without entry procedure', function (accounts) {
 
                 const valueX = await kernel.executeProcedure.call(procName, functionSpec, "");
                 const tx = await kernel.executeProcedure(procName, functionSpec, "");
-
+                // console.log(tx)
+                // for (const log of tx.receipt.logs) {
+                //     if (log.topics.length > 0) {
+                //         console.log(`Log: ${web3.toAscii(log.topics[0])} - ${log.data} - ${web3.toAscii(log.data)}`);
+                //     } else {
+                //         console.log(`Log: ${log.topics[0]} - ${web3.toAscii(log.data)} - ${log.data}`);
+                //     }
+                // }
                 assert.equal(valueX.toNumber(), 0, "should succeed with zero errcode the first time");
 
                 const newValue =  await kernel.testGetter.call();
@@ -484,6 +491,8 @@ contract('Kernel without entry procedure', function (accounts) {
                 const cap2 = new beakerlib.LogCap([]);
                 const cap3 = new beakerlib.CallCap();
                 const capArray = beakerlib.Cap.toInput([cap1, cap2, cap3]);
+                
+                kernel.allEvents().watch(console.log)
 
                 const deployedContract = await testutils.deployedTrimmed(contract);
                 const deployedTestContract = await testutils.deployedTrimmed(testContract);
@@ -494,7 +503,15 @@ contract('Kernel without entry procedure', function (accounts) {
 
                 const newValue = await kernel.executeProcedure.call(procName, functionSpec, "");
                 const tx = await kernel.executeProcedure(procName, functionSpec, "");
-
+                // console.log(tx)
+                // for (const log of tx.receipt.logs) {
+                //     if (log.topics.length > 0) {
+                //         console.log(`Log: ${web3.toAscii(log.topics[0])} - ${log.data} - ${web3.toAscii(log.data)}`);
+                //     } else {
+                //         console.log(`Log: ${log.topics[0]} - ${log.data}`);
+                //     }
+                // }
+                // console.log(newValue)
                 assert.equal(newValue.toNumber(),8, `new value should be 8`);
             })
             it('E() should fail when not given cap', async function () {
@@ -624,7 +641,7 @@ contract('Kernel without entry procedure', function (accounts) {
                 assert.equal(newValue2.toNumber(),4, "new value should be 4");
             })
         })
-        describe('G() - deeper stacks', function () {
+        describe.only('G() - deeper stacks', function () {
             const testProcName = "FirstNestedCall";
             const testBytecode = Valid.FirstNestedCall.bytecode;
             const functionSpec = "G()";


### PR DESCRIPTION
Created `proc_call(uint8 capIndex, bytes32 procId, string fselector, uint32[] input) internal returns (uint32 err, bytes memory output)` for #81