### PR TITLE
Rename Logs Fns to Proc_Log

### DIFF
--- a/contracts/BeakerContract.sol
+++ b/contracts/BeakerContract.sol
@@ -256,7 +256,7 @@ contract BeakerContract is IKernel {
     return err;
   }
 
-  function log0(uint8 capIndex, uint32 value) internal returns (uint32 err) {
+  function proc_log0(uint8 capIndex, uint32 value) internal returns (uint32 err) {
       assembly {
             function mallocZero(size) -> result {
                 // align to 32-byte words
@@ -302,7 +302,7 @@ contract BeakerContract is IKernel {
         }
         return err;
   }
-  function log1(uint8 capIndex, uint32 t1, uint32 value) internal returns (uint32 err) {
+  function proc_log1(uint8 capIndex, uint32 t1, uint32 value) internal returns (uint32 err) {
       assembly {
             function mallocZero(size) -> result {
                 // align to 32-byte words
@@ -353,7 +353,7 @@ contract BeakerContract is IKernel {
         return err;
   }
 
-  function log2(uint8 capIndex, uint32 t1, uint32 t2, uint32 value) internal returns (uint32 err) {
+  function proc_log2(uint8 capIndex, uint32 t1, uint32 t2, uint32 value) internal returns (uint32 err) {
       assembly {
             function mallocZero(size) -> result {
                 // align to 32-byte words
@@ -404,7 +404,7 @@ contract BeakerContract is IKernel {
         }
     return err;
   }
-  function log3(uint8 capIndex, uint32 t1, uint32 t2, uint32 t3, uint32 value) internal returns (uint32 err) {
+  function proc_log3(uint8 capIndex, uint32 t1, uint32 t2, uint32 t3, uint32 value) internal returns (uint32 err) {
       assembly {
             function mallocZero(size) -> result {
                 // align to 32-byte words
@@ -458,7 +458,7 @@ contract BeakerContract is IKernel {
         return err;
   }
 
-  function log4(uint8 capIndex, uint32 t1, uint32 t2, uint32 t3, uint32 t4, uint32 value) internal returns (uint32 err) {
+  function proc_log4(uint8 capIndex, uint32 t1, uint32 t2, uint32 t3, uint32 t4, uint32 value) internal returns (uint32 err) {
       assembly {
             function mallocZero(size) -> result {
                 // align to 32-byte words

--- a/contracts/test/valid/SysCallTestLog.sol
+++ b/contracts/test/valid/SysCallTestLog.sol
@@ -5,27 +5,27 @@ import "../../BeakerContract.sol";
 contract SysCallTestLog is BeakerContract {
     // Log to no topics
     function A() public returns (uint32) {
-        return log0(1, uint32(0x1234567890));
+        return proc_log0(1, uint32(0x1234567890));
     }
 
     // Log to a single topic
     function B() public {
-        log1(1, 0xabcd, uint32(0x1234567890));
+        proc_log1(1, 0xabcd, uint32(0x1234567890));
     }
 
     // Log to two topics
     function C() public {
-        log2(1, 0xabcd, 0xbeef, uint32(0x1234567890));
+        proc_log2(1, 0xabcd, 0xbeef, uint32(0x1234567890));
     }
 
     // Log to three topics
     function D() public {
-        log3(1, 0xabcd, 0xbeef, 0xcafe, uint32(0x1234567890));
+        proc_log3(1, 0xabcd, 0xbeef, 0xcafe, uint32(0x1234567890));
     }
 
     // Log to four topics
     function E() public {
-        log4(1, 0xabcd, 0xbeef, 0xcafe, 0x4545, uint32(0x1234567890));
+        proc_log4(1, 0xabcd, 0xbeef, 0xcafe, 0x4545, uint32(0x1234567890));
 
     }
 }


### PR DESCRIPTION
For #97. Append `proc_` to log calls