### PR TITLE
Implement capability for setting entry procedure.

### DIFF
--- a/beakerlib/index.js
+++ b/beakerlib/index.js
@@ -177,6 +177,22 @@ class DeleteCap extends Cap {
 }
 exports.DeleteCap = DeleteCap;
 
+class SetEntryCap extends Cap {
+    // A DeleteCap is just a boolean value, a procedure can or cannot
+    // register new procedures
+    constructor() {
+        super(CAP_TYPE.PROC_ENTRY);
+        this.keys = [];
+    }
+    // Format the capability values into the values that will be stored in the
+    // kernel. Must be defined for all subclasses
+    keyValues() {
+        const val = Array.from(this.keys.map(x => web3.fromAscii(x.padEnd(32, '\0'))));
+        return val;
+    }
+}
+exports.SetEntryCap = SetEntryCap;
+
 exports.SysCallResponse = {
     SUCCESS: 0,
     READFAILURE: 11,

--- a/contracts/Kernel.sol
+++ b/contracts/Kernel.sol
@@ -156,6 +156,8 @@ contract Kernel is Factory, IKernel {
             _procRegSystemCall();
         } else if (sysCallCapType == CAP_PROC_DELETE) {
             _procDelSystemCall();
+        } else if (sysCallCapType == CAP_PROC_ENTRY) {
+            _setEntrySystemCall();
         } else {
             // default; fallthrough action
             assembly {
@@ -402,6 +404,51 @@ contract Kernel is Factory, IKernel {
         }
     }
 
+    function _setEntrySystemCall() internal {
+        // This is a procedure-delete system call
+        // this is the system call to delete a contract as a procedure
+        // currently we enforce no caps
+
+        uint256 capIndex = parse32ByteValue(1);
+        // TODO: fix this double name variable work-around
+        bytes32 regNameB = bytes32(parse32ByteValue(1+32));
+        bytes24 regName = bytes24(regNameB);
+        bool cap = procedures.checkSetEntryCapability(uint192(currentProcedure), capIndex);
+        if (cap) {
+            (uint8 err) = _setEntryProcedure(regName);
+            uint256 bigErr = uint256(err);
+            assembly {
+                function mallocZero(size) -> result {
+                    // align to 32-byte words
+                    let rsize := add(size,sub(32,mod(size,32)))
+                    // get the current free mem location
+                    result :=  mload(0x40)
+                    // zero-out the memory
+                    // if there are some bytes to be allocated (rsize is not zero)
+                    if rsize {
+                        // loop through the address and zero them
+                        for { let n := 0 } iszero(eq(n, rsize)) { n := add(n, 32) } {
+                            mstore(add(result,n),0)
+                        }
+                    }
+                    // Bump the value of 0x40 so that it holds the next
+                    // available memory location.
+                    mstore(0x40,add(result,rsize))
+                }
+                let retSize := 32
+                let retLoc := mallocZero(retSize)
+                mstore(retLoc,bigErr)
+                return(retLoc,retSize)
+            }
+        } else {
+            assembly {
+                // 33 means the capability was rejected
+                mstore(0,33)
+                revert(0,0x20)
+            }
+        }
+    }
+
     function _storeSystemCall() internal {
         // This is a store system call
         // Here we have established that we are processing a write call and
@@ -518,6 +565,12 @@ contract Kernel is Factory, IKernel {
         retAddress = procedureAddress;
         err = 0;
         return (0, procedureAddress);
+    }
+
+    function _setEntryProcedure(bytes24 name) internal returns (uint8 err) {
+        // TODO: check that the procedure exists
+        entryProcedure = name;
+        err = 0;
     }
 
     function _deleteProcedure(bytes24 name) internal returns (uint8 err, address procedureAddress) {

--- a/contracts/ProcedureTable.sol
+++ b/contracts/ProcedureTable.sol
@@ -162,6 +162,29 @@ library ProcedureTable {
         }
     }
 
+    function checkSetEntryCapability(Self storage /* self */, uint192 key, uint256 reqCapIndex) internal view returns (bool) {
+        Procedure memory p = _getProcedureByKey(uint192(key));
+
+        // If the requested cap is out of the bounds of the cap table, we
+        // clearly don't have the capability;
+        if ((p.caps.length == 0) || (reqCapIndex > (p.caps.length - 1))) {
+            return false;
+        }
+        Capability memory cap = p.caps[reqCapIndex];
+        // If the capability type is not ENTRY it is the wrong type of
+        // capability and we should reject
+        if (cap.capType != CAP_PROC_ENTRY) {
+            return false;
+        }
+        // If the cap is empty it implies all procedures are ok
+        if (cap.values.length == 0) {
+            return true;
+        } else {
+            // the register cap should always be empty, otherwise it is invalid
+            return false;
+        }
+    }
+
     function checkCallCapability(Self storage /* self */, uint192 key, bytes24 procedureKey, uint256 reqCapIndex) internal view returns (bool) {
         Procedure memory p = _getProcedureByKey(uint192(key));
 


### PR DESCRIPTION
This is an implementation for the capability and system call to set the entry procedure. It's a fairly simple syscall. The only remaining question is what to do when it is requested to set the entry procedure to a procedure name which doesn't exist. If the entry is set to a non-existent procedure it bricks the kernel. My thoughts are that we should allow that, with my reasoning as follows:

1. This is essentially error checking that throws an error if you do something silly.
2. This adds code complexity to the kernel to prevent a very trivial mistake. This mistake can be trivially caught "user side" in client code.
3. It might be an elegant way to brick a kernel.

Any thoughts on what the behaviour should be here? I'm in favour of allowing the entry key to be set to anything.