### PR TITLE
Use cross platform CWD.

### DIFF
--- a/kernel-ewasm/tests/integration/index.js
+++ b/kernel-ewasm/tests/integration/index.js
@@ -5,10 +5,10 @@ const http = require('http')
 const assert = require('assert')
 
 // Get BuildPath
-const BUILD_PATH = path.resolve(process.env.PWD, './build')
+const BUILD_PATH = path.resolve(process.cwd(), './build')
 
 // Get Dev Chain Config
-const CHAIN_CONFIG = require(path.resolve(process.env.PWD, './wasm-dev-chain.json'));
+const CHAIN_CONFIG = require(path.resolve(process.cwd(), './wasm-dev-chain.json'));
 
 // Web3 Config
 const WEB3_OPTIONS = {


### PR DESCRIPTION
`process.env.PWD` is Unix (I think) specific. `process.cwd()` is the cross platform way to do it.