### PR TITLE
Fix link errors for offline tests

### DIFF
--- a/kernel-ewasm/cap9-std/Cargo.toml
+++ b/kernel-ewasm/cap9-std/Cargo.toml
@@ -11,6 +11,7 @@ pwasm-abi = "0.2"
 
 [dev-dependencies]
 pwasm-abi-derive = "0.2"
+cap9-test = { path = "../cap9-test" }
 
 [dev-dependencies.pwasm-test]
 git = "https://github.com/paritytech/pwasm-test"

--- a/kernel-ewasm/cap9-std/Cargo.toml
+++ b/kernel-ewasm/cap9-std/Cargo.toml
@@ -11,8 +11,7 @@ pwasm-abi = "0.2"
 
 [dev-dependencies]
 pwasm-abi-derive = "0.2"
-cap9-test = { path = "../cap9-test" }
 
-[dev-dependencies.pwasm-test]
-git = "https://github.com/paritytech/pwasm-test"
-default-features = true
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+cap9-test = { path = "../cap9-test" }
+pwasm-test = { git = "https://github.com/paritytech/pwasm-test", default-features = true }

--- a/kernel-ewasm/cap9-std/examples/entry_test.rs
+++ b/kernel-ewasm/cap9-std/examples/entry_test.rs
@@ -1,10 +1,20 @@
 #![no_std]
-#![no_main]
 #![allow(non_snake_case)]
 
 extern crate cap9_std;
 extern crate pwasm_std;
 extern crate pwasm_abi_derive;
+
+// When we are compiling to WASM, unresolved references are left as (import)
+// expressions. However, under any other target symbols will have to be linked
+// for EVM functions (blocknumber, create, etc.). Therefore, when we are not
+// compiling for WASM (be it test, realse, whatever) we want to link in dummy
+// functions. pwasm_test provides all the builtins provided by parity, while
+// cap9_test covers the few that we have implemented ourselves.
+#[cfg(not(target_arch = "wasm32"))]
+extern crate pwasm_test;
+#[cfg(not(target_arch = "wasm32"))]
+extern crate cap9_test;
 
 fn main() {}
 
@@ -17,7 +27,7 @@ pub mod entry {
     pub trait TestEntryInterface {
         /// The constructor set with Initial Entry Procedure
         fn constructor(&mut self);
-        
+
         /// Get Number
         #[constant]
         fn getNum(&mut self) -> U256;
@@ -27,7 +37,7 @@ pub mod entry {
     pub struct EntryContract;
 
     impl TestEntryInterface for EntryContract {
-        
+
         fn constructor(&mut self) {}
 
         fn getNum(&mut self) -> U256 {

--- a/kernel-ewasm/cap9-std/examples/writer2_test.rs
+++ b/kernel-ewasm/cap9-std/examples/writer2_test.rs
@@ -1,11 +1,21 @@
 #![cfg_attr(not(feature="std"), no_std)]
-#![no_main]
 #![allow(non_snake_case)]
 
 extern crate pwasm_std;
 extern crate pwasm_ethereum;
 extern crate pwasm_abi;
 extern crate pwasm_abi_derive;
+
+// When we are compiling to WASM, unresolved references are left as (import)
+// expressions. However, under any other target symbols will have to be linked
+// for EVM functions (blocknumber, create, etc.). Therefore, when we are not
+// compiling for WASM (be it test, realse, whatever) we want to link in dummy
+// functions. pwasm_test provides all the builtins provided by parity, while
+// cap9_test covers the few that we have implemented ourselves.
+#[cfg(not(target_arch = "wasm32"))]
+extern crate pwasm_test;
+#[cfg(not(target_arch = "wasm32"))]
+extern crate cap9_test;
 
 use pwasm_abi::types::*;
 use pwasm_abi_derive::eth_abi;

--- a/kernel-ewasm/cap9-std/examples/writer_test.rs
+++ b/kernel-ewasm/cap9-std/examples/writer_test.rs
@@ -1,10 +1,20 @@
 #![no_std]
-#![no_main]
 #![allow(non_snake_case)]
 
 extern crate cap9_std;
 extern crate pwasm_std;
 extern crate pwasm_abi_derive;
+
+// When we are compiling to WASM, unresolved references are left as (import)
+// expressions. However, under any other target symbols will have to be linked
+// for EVM functions (blocknumber, create, etc.). Therefore, when we are not
+// compiling for WASM (be it test, realse, whatever) we want to link in dummy
+// functions. pwasm_test provides all the builtins provided by parity, while
+// cap9_test covers the few that we have implemented ourselves.
+#[cfg(not(target_arch = "wasm32"))]
+extern crate pwasm_test;
+#[cfg(not(target_arch = "wasm32"))]
+extern crate cap9_test;
 
 fn main() {}
 
@@ -18,7 +28,7 @@ pub mod writer {
     pub trait TestWriterInterface {
         /// The constructor set with Initial Entry Procedure
         fn constructor(&mut self);
-        
+
         /// Get Number
         #[constant]
         fn getNum(&mut self, key: U256) -> U256;
@@ -30,7 +40,7 @@ pub mod writer {
     pub struct WriterContract;
 
     impl TestWriterInterface for WriterContract {
-        
+
         fn constructor(&mut self) {}
 
         fn getNum(&mut self, key: U256) -> U256 {

--- a/kernel-ewasm/cap9-std/src/lib.rs
+++ b/kernel-ewasm/cap9-std/src/lib.rs
@@ -9,6 +9,17 @@ pub struct Error;
 
 pub mod proc_table;
 
+// When we are compiling to WASM, unresolved references are left as (import)
+// expressions. However, under any other target symbols will have to be linked
+// for EVM functions (blocknumber, create, etc.). Therefore, when we are not
+// compiling for WASM (be it test, realse, whatever) we want to link in dummy
+// functions. pwasm_test provides all the builtins provided by parity, while
+// cap9_test covers the few that we have implemented ourselves.
+#[cfg(not(target_arch = "wasm32"))]
+extern crate pwasm_test;
+#[cfg(not(target_arch = "wasm32"))]
+extern crate cap9_test;
+
 /// TODO: this is duplicated from pwasm_ethereum as it is currently in a private
 /// module.
 pub mod external {
@@ -35,7 +46,7 @@ pub mod external {
         /// the lowest level, therefore it's arguments are all the non-compulsory
         /// parts of a delgate call. That is, the signature of a delegate call is
         /// this:
-        /// 
+        ///
         ///   dcall( gas: i64, address: *const u8, input_ptr: *const u8, input_len:
         ///      u32, result_ptr: *mut u8, result_len: u32, ) -> i32
         ///
@@ -45,8 +56,8 @@ pub mod external {
         #[no_mangle]
         pub fn cap9_syscall_low(input_ptr: *const u8, input_len: u32, result_ptr: *mut u8, result_len: u32) -> i32;
 
-        
-    }   
+
+    }
 
 }
 
@@ -74,7 +85,7 @@ pub fn extcodecopy(address: &Address) -> pwasm_std::Vec<u8> {
 /// over cap9_syscall_low that uses Result types and the like. This is by no
 /// means part of the spec, but more ergonomic Rust level library code. Actual
 /// syscalls should be built on top of this.
-/// 
+///
 /// # Errors
 ///
 /// Returns [`Error`] in case syscall returns error
@@ -103,4 +114,3 @@ pub fn raw_proc_write(cap_index: u8, key: &[u8; 32], value: &[u8; 32]) -> Result
 
     cap9_syscall(&input, &mut Vec::new())
 }
-

--- a/kernel-ewasm/cap9-test/Cargo.toml
+++ b/kernel-ewasm/cap9-test/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "cap9-test"
+version = "0.1.0"
+authors = ["DaoHub <info@daohub.io>"]
+edition = "2018"

--- a/kernel-ewasm/cap9-test/src/lib.rs
+++ b/kernel-ewasm/cap9-test/src/lib.rs
@@ -1,0 +1,33 @@
+#![no_std]
+
+#[no_mangle]
+pub extern fn extcodesize( address: *const u8) -> i32 {
+    panic!("extcodesize not available")
+}
+
+#[no_mangle]
+pub extern fn extcodecopy( dest: *mut u8, address: *const u8) {
+    panic!("extcodecopy not available");
+}
+
+// #[no_mangle]
+// pub extern fn dcall(
+//             gas: i64,
+//             address: *const u8,
+//             input_ptr: *const u8,
+//             input_len: u32,
+//             result_ptr: *mut u8,
+//             result_len: u32,
+//     ) -> i32 {
+//         panic!("dcall not available")
+//     }
+
+#[no_mangle]
+pub extern fn cap9_syscall_low(input_ptr: *const u8, input_len: u32, result_ptr: *mut u8, result_len: u32) -> i32 {
+    panic!("cap9_syscall_low not available")
+}
+
+#[no_mangle]
+pub extern fn gasleft() -> i64 {
+    panic!("gasleft not available");
+}


### PR DESCRIPTION
When we are compiling to WASM, unresolved references are left as (import) expressions. However, under any other target symbols will have to be linked for EVM functions (blocknumber, create, etc.). Therefore, when we are not compiling for WASM (be it test, realse, whatever) we want to link in dummy functions. pwasm_test provides all the builtins provided by parity, while cap9_test covers the few that we have implemented ourselves.

This should affect the integration tests (i.e. with the node) but it does allow us to test and build everything "offline" without any errors.

Of course, linking problems are finnicky and hard to get right. Give it a try and see if I haven't broken everything,