### PR TITLE
Implement the WRITE syscall

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,3 +143,4 @@ jobs:
             cd cap9
             cd kernel-ewasm && npm install
             npm run test
+            cargo test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,10 +43,10 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            - deps7-{{ .Branch }}-{{ .Revision }}
-            # - deps7-{{ .Branch }}-cargo-{{ checksum "kernel-ewasm/Cargo.lock" }}
-            - deps7-{{ .Branch }}-
-            - deps7-
+            - deps8-{{ .Branch }}-{{ .Revision }}
+            # - deps8-{{ .Branch }}-cargo-{{ checksum "kernel-ewasm/Cargo.lock" }}
+            - deps8-{{ .Branch }}-
+            - deps8-
       - run:
           name: Install native build prequisites
           command: |
@@ -92,7 +92,6 @@ jobs:
             cd parity-ethereum
             git fetch --all
             git checkout master
-            git pull
             # cargo build -j 1
             # cargo build --verbose --release --features final
             # strip target/debug/parity
@@ -103,7 +102,7 @@ jobs:
               cargo install --bin parity -j 1 --path . --bin parity parity-ethereum
             fi
       - save_cache:
-          key: deps7-{{ .Branch }}-cargo #-{{ checksum "kernel-ewasm/Cargo.lock" }}
+          key: deps8-{{ .Branch }}-cargo #-{{ checksum "kernel-ewasm/Cargo.lock" }}
           paths:
             - "~/.cargo"
             - "~/.rustup"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,10 +43,10 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            - deps8-{{ .Branch }}-{{ .Revision }}
-            # - deps8-{{ .Branch }}-cargo-{{ checksum "kernel-ewasm/Cargo.lock" }}
-            - deps8-{{ .Branch }}-
-            - deps8-
+            - deps9-{{ .Branch }}-{{ .Revision }}
+            # - deps9-{{ .Branch }}-cargo-{{ checksum "kernel-ewasm/Cargo.lock" }}
+            - deps9-{{ .Branch }}-
+            - deps9-
       - run:
           name: Install native build prequisites
           command: |
@@ -102,7 +102,7 @@ jobs:
               cargo install --bin parity -j 1 --path . --bin parity parity-ethereum
             fi
       - save_cache:
-          key: deps8-{{ .Branch }}-cargo #-{{ checksum "kernel-ewasm/Cargo.lock" }}
+          key: deps9-{{ .Branch }}-cargo #-{{ checksum "kernel-ewasm/Cargo.lock" }}
           paths:
             - "~/.cargo"
             - "~/.rustup"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ jobs:
             cd parity-ethereum
             git fetch --all
             git checkout master
+            git pull
             # cargo build -j 1
             # cargo build --verbose --release --features final
             # strip target/debug/parity

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
             # timeout 5 parity --config dev || true
             # We then run parity properly, now unlocking the previously setup
             # account
-            parity  --config dev --chain ./wasm-dev-chain.json --jsonrpc-apis=all --ws-apis=all --reseal-min-period 0 --gasprice 0
+            parity  --config dev --chain ./wasm-dev-chain.json --jsonrpc-apis=all --ws-apis=all --reseal-min-period 0 --gasprice 0 --geth
           background: true
       - run:
           name: Wait for Parity startup

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ chain
 kernel-ewasm/target/*
 **/*.rs.bk
 Cargo.lock
+
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,6 @@ chain
 #
 #already existing elements are commented out
 
-<<<<<<< HEAD
 kernel-ewasm/target/*
-=======
-/target
->>>>>>> e02a2624942c5311a30ad3a7aec794205a6c762a
 **/*.rs.bk
 Cargo.lock

--- a/kernel-ewasm/Cargo.toml
+++ b/kernel-ewasm/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "cap9-build",
     "cap9-kernel",
     "cap9-std",
+    "cap9-test",
     "validator"
 ]
 

--- a/kernel-ewasm/README.md
+++ b/kernel-ewasm/README.md
@@ -53,12 +53,12 @@ cargo test --package cap9-kernel --features std
 parity  --config dev --chain ./wasm-dev-chain.json db kill
 
 # Run Parity Dev Chain in seperate shell
-parity  --config dev --chain ./wasm-dev-chain.json --jsonrpc-apis=all --ws-apis=all --reseal-min-period 0 --gasprice 0
+parity  --config dev --chain ./wasm-dev-chain.json --jsonrpc-apis=all --ws-apis=all --reseal-min-period 0 --gasprice 0 --geth
 
 # Setup Test Account (if not created)
 curl --data '{"jsonrpc":"2.0","method":"parity_newAccountFromPhrase","params":["user", "user"],"id":0}' -H "Content-Type: application/json" -X POST localhost:8545
 
-# Run Npm 
+# Run Npm
 npm test
 
 ```

--- a/kernel-ewasm/cap9-build/src/main.rs
+++ b/kernel-ewasm/cap9-build/src/main.rs
@@ -177,8 +177,20 @@ fn get_syscall_instructions(module: &Module) -> Result<Instructions,SysCallError
     let syscall_instructions = parity_wasm::elements::Instructions::new(vec![
         // Call gas
         Instruction::Call(gasleft_index),
-        // Call sender
+        // Call sender, this will place the sender somewhere in memory,
+        // therefore we need to allocate or something. An address is 160 bits
+        // long, and therefore can't fit into a word. We need to place a
+        // location here first.
+        // TODO: allocate this memory rather than picking a random location.
+        //
+        // Place a memory location for the "sender" function to place the
+        // address.
+        Instruction::I32Const(80000),
+        // Call the sender to function to place the address in memory.
         Instruction::Call(sender_index),
+        // Place the same memory location on the stack again for use by the
+        // dcall function.
+        Instruction::I32Const(80000),
         Instruction::GetLocal(0),
         Instruction::GetLocal(1),
         Instruction::GetLocal(2),

--- a/kernel-ewasm/cap9-build/src/main.rs
+++ b/kernel-ewasm/cap9-build/src/main.rs
@@ -177,6 +177,9 @@ fn get_syscall_instructions(module: &Module) -> Result<Instructions,SysCallError
     let syscall_instructions = parity_wasm::elements::Instructions::new(vec![
         // Call gas
         Instruction::Call(gasleft_index),
+        // TODO: this subtraction is a little hacky
+        Instruction::I64Const(10000),
+        Instruction::I64Sub,
         // Call sender, this will place the sender somewhere in memory,
         // therefore we need to allocate or something. An address is 160 bits
         // long, and therefore can't fit into a word. We need to place a
@@ -187,6 +190,7 @@ fn get_syscall_instructions(module: &Module) -> Result<Instructions,SysCallError
         // address.
         Instruction::I32Const(80000),
         // Call the sender to function to place the address in memory.
+        // TODO: because of the lack of call code, this will be incorrect.
         Instruction::Call(sender_index),
         // Place the same memory location on the stack again for use by the
         // dcall function.

--- a/kernel-ewasm/cap9-kernel/Cargo.toml
+++ b/kernel-ewasm/cap9-kernel/Cargo.toml
@@ -14,7 +14,7 @@ pwasm-abi-derive = "0.2"
 parity-wasm = { git = "https://github.com/paritytech/parity-wasm.git", default-features = false }
 lazy_static = { version = "1.2.0", features = ["spin_no_std"] }
 validator = { path = "../validator", default-features = false }
-cap9-std = { path = "../cap9-std" }
+cap9-std = { path = "../cap9-std", default-features = false}
 
 [dev-dependencies.pwasm-test]
 git = "https://github.com/paritytech/pwasm-test"
@@ -27,4 +27,4 @@ crate-type = ["cdylib"]
 [features]
 default = ["std"]
 std = ["pwasm-std/std", "pwasm-ethereum/std", "pwasm-test/std"]
-panic_with_msg = ["pwasm-std/panic_with_msg"]
+panic_with_msg = ["pwasm-std/panic_with_msg", "cap9-std/panic_with_msg"]

--- a/kernel-ewasm/cap9-kernel/src/lib.rs
+++ b/kernel-ewasm/cap9-kernel/src/lib.rs
@@ -28,7 +28,7 @@ pub mod kernel {
     use pwasm_abi::types::*;
     use validator::{Validity, Module};
     use pwasm_ethereum;
-    
+
     use crate::proc_table;
     use crate::proc_table::cap;
 
@@ -60,7 +60,7 @@ pub mod kernel {
 
         /// Toggle Syscall Mode
         /// (Forwards all calls to entry procedure)
-        /// 
+        ///
         /// _Temporary for debugging purposes_
         fn toggle_syscall(&mut self);
     }
@@ -68,7 +68,7 @@ pub mod kernel {
     pub struct KernelContract;
 
     impl KernelInterface for KernelContract {
-        
+
         fn constructor(&mut self, _entry_proc_key: String, _entry_proc_address: Address, _cap_list: Vec<U256>) {
             let _entry_proc_key = {
                 let byte_key = _entry_proc_key.as_bytes();
@@ -151,9 +151,10 @@ use pwasm_abi::eth::EndpointInterface;
 
 #[no_mangle]
 pub fn call() {
+    panic!("call-panic");
     let mut current_val = pwasm_ethereum::read(&H256(TEST_KERNEL_SYSCALL_TOGGLE_PTR));
-    
-    // TODO: Remove Toggling and replace current Kernel Interface with Standard Entry Procedure Interface 
+
+    // TODO: Remove Toggling and replace current Kernel Interface with Standard Entry Procedure Interface
     //
     // If Toggled Run Entry Procedure
     if current_val[0] == 1 {

--- a/kernel-ewasm/cap9-kernel/src/lib.rs
+++ b/kernel-ewasm/cap9-kernel/src/lib.rs
@@ -63,6 +63,8 @@ pub mod kernel {
         ///
         /// _Temporary for debugging purposes_
         fn toggle_syscall(&mut self);
+
+        fn panic(&mut self);
     }
 
     pub struct KernelContract;
@@ -143,6 +145,9 @@ pub mod kernel {
             pwasm_ethereum::write(&H256(super::TEST_KERNEL_SYSCALL_TOGGLE_PTR), &current_val);
         }
 
+        fn panic(&mut self) {
+            panic!("test-panic")
+        }
     }
 }
 
@@ -151,7 +156,6 @@ use pwasm_abi::eth::EndpointInterface;
 
 #[no_mangle]
 pub fn call() {
-    panic!("call-panic");
     let mut current_val = pwasm_ethereum::read(&H256(TEST_KERNEL_SYSCALL_TOGGLE_PTR));
 
     // TODO: Remove Toggling and replace current Kernel Interface with Standard Entry Procedure Interface

--- a/kernel-ewasm/cap9-kernel/src/lib.rs
+++ b/kernel-ewasm/cap9-kernel/src/lib.rs
@@ -210,10 +210,10 @@ pub fn call() {
             let mut input = Cursor::new(pwasm_ethereum::input());
             // Attempt to deserialize the input into a syscall. Panic on
             // deserialization failure.
-            let syscall: SysCall = SysCall::deserialize(&mut input).unwrap();
+            let syscall: SysCallAction = SysCallAction::deserialize(&mut input).unwrap();
             match syscall {
                 // WRITE syscall
-                SysCall::Write(k,v) => {
+                SysCallAction::Write(k,v) => {
                     pwasm_ethereum::write(&k.into(), &v.into());
                     pwasm_ethereum::ret(&[]);
                 },

--- a/kernel-ewasm/cap9-kernel/src/lib.rs
+++ b/kernel-ewasm/cap9-kernel/src/lib.rs
@@ -163,6 +163,7 @@ pub fn call() {
         // We don't have `returnDataSize` or `returnDataCopy`, https://github.com/ewasm/design/blob/master/eth_interface.md#getreturndatasize
         // So we'll simply allocate a large result buffer for now
         let mut result = [6; 32].to_vec();
+        // NB: This "call_code" is a DELEGATECALL not a CALLCODE.
         pwasm_ethereum::call_code(1000, &entry_address, &pwasm_ethereum::input(), &mut result).expect("Invalid Entry Proc");
         pwasm_ethereum::ret(&result);
 

--- a/kernel-ewasm/cap9-kernel/src/lib.rs
+++ b/kernel-ewasm/cap9-kernel/src/lib.rs
@@ -210,11 +210,11 @@ pub fn call() {
             let mut input = Cursor::new(pwasm_ethereum::input());
             // Attempt to deserialize the input into a syscall. Panic on
             // deserialization failure.
-            let syscall: SysCallAction = SysCallAction::deserialize(&mut input).unwrap();
-            match syscall {
+            let syscall: SysCall = SysCall::deserialize(&mut input).unwrap();
+            match syscall.action {
                 // WRITE syscall
-                SysCallAction::Write(k,v) => {
-                    pwasm_ethereum::write(&k.into(), &v.into());
+                SysCallAction::Write(WriteCall{key,value}) => {
+                    pwasm_ethereum::write(&key.into(), &value.into());
                     pwasm_ethereum::ret(&[]);
                 },
             }

--- a/kernel-ewasm/cap9-kernel/src/lib.rs
+++ b/kernel-ewasm/cap9-kernel/src/lib.rs
@@ -211,6 +211,12 @@ pub fn call() {
             // Attempt to deserialize the input into a syscall. Panic on
             // deserialization failure.
             let syscall: SysCall = SysCall::deserialize(&mut input).unwrap();
+            // Before we perform any actions, we want to check that this
+            // procedure has the correct capabilities. As a smoke test, let's
+            // just check that the cap_index is zero.
+            if syscall.cap_index != 0 {
+                panic!("wrong cap index");
+            }
             match syscall.action {
                 // WRITE syscall
                 SysCallAction::Write(WriteCall{key,value}) => {

--- a/kernel-ewasm/cap9-kernel/src/lib.rs
+++ b/kernel-ewasm/cap9-kernel/src/lib.rs
@@ -200,11 +200,7 @@ pub fn call() {
             pwasm_ethereum::call_code(pwasm_ethereum::gas_left()-10000, &entry_address, &pwasm_ethereum::input(), &mut result_buffer).expect("Invalid Entry Proc");
             // Unset the current procedure
             proc_table::set_current_proc_id([0; 24]);
-            if pwasm_ethereum::input()[0] == 0xf3 {
-                pwasm_ethereum::ret(&result_buffer);
-            } else {
-                pwasm_ethereum::ret(&[]);
-            }
+            pwasm_ethereum::ret(&result());
         } else {
             // We are currently executing the procedure identified by
             // 'current_proc', therefore we should interpret this as a system

--- a/kernel-ewasm/cap9-kernel/src/lib.rs
+++ b/kernel-ewasm/cap9-kernel/src/lib.rs
@@ -64,6 +64,8 @@ pub mod kernel {
         /// _Temporary for debugging purposes_
         fn toggle_syscall(&mut self);
 
+        fn get_mode(&mut self) -> u32;
+
         fn panic(&mut self);
     }
 
@@ -145,6 +147,11 @@ pub mod kernel {
             pwasm_ethereum::write(&H256(super::TEST_KERNEL_SYSCALL_TOGGLE_PTR), &current_val);
         }
 
+        fn get_mode(&mut self) -> u32 {
+            let current_val = pwasm_ethereum::read(&H256(super::TEST_KERNEL_SYSCALL_TOGGLE_PTR));
+            current_val[0] as u32
+        }
+
         fn panic(&mut self) {
             panic!("test-panic")
         }
@@ -161,6 +168,8 @@ pub fn call() {
     // TODO: Remove Toggling and replace current Kernel Interface with Standard Entry Procedure Interface
     //
     // If Toggled Run Entry Procedure
+    // Once the entry procedure is toggled on, there is no existing mechanism to
+    // turn it off.
     if current_val[0] == 1 {
         let entry_address = proc_table::get_proc_addr(proc_table::get_entry_proc_id()).expect("No Entry Proc");
 

--- a/kernel-ewasm/cap9-std/Cargo.toml
+++ b/kernel-ewasm/cap9-std/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["DaoHub <info@daohub.io>"]
 edition = "2018"
 
 [dependencies]
-pwasm-std = { version = "0.13", features = ["std"] }
+pwasm-std = { version = "0.13", default-features = false }
 pwasm-ethereum = { version = "0.8", features = ["kip6"] }
 pwasm-abi = "0.2"
 
@@ -14,4 +14,9 @@ pwasm-abi-derive = "0.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cap9-test = { path = "../cap9-test" }
-pwasm-test = { git = "https://github.com/paritytech/pwasm-test", default-features = true }
+pwasm-test = { git = "https://github.com/paritytech/pwasm-test", default-features = false }
+
+[features]
+default = ["std"]
+std = ["pwasm-std/std", "pwasm-ethereum/std", "pwasm-test/std"]
+panic_with_msg = ["pwasm-std/panic_with_msg"]

--- a/kernel-ewasm/cap9-std/Cargo.toml
+++ b/kernel-ewasm/cap9-std/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 pwasm-std = { version = "0.13", default-features = false }
 pwasm-ethereum = { version = "0.8", features = ["kip6"] }
 pwasm-abi = "0.2"
+validator = { path = "../validator", default-features = false }
 
 [dev-dependencies]
 pwasm-abi-derive = "0.2"

--- a/kernel-ewasm/cap9-std/examples/entry_test.rs
+++ b/kernel-ewasm/cap9-std/examples/entry_test.rs
@@ -20,7 +20,6 @@ fn main() {}
 
 pub mod entry {
     use pwasm_abi::types::*;
-    use pwasm_ethereum;
     use pwasm_abi_derive::eth_abi;
 
     #[eth_abi(TestEntryEndpoint, KernelClient)]

--- a/kernel-ewasm/cap9-std/examples/writer2_test.rs
+++ b/kernel-ewasm/cap9-std/examples/writer2_test.rs
@@ -18,7 +18,6 @@ extern crate pwasm_test;
 extern crate cap9_test;
 
 use pwasm_abi::types::*;
-use pwasm_abi_derive::eth_abi;
 use pwasm_ethereum::Error;
 
 fn main() {}
@@ -101,16 +100,15 @@ pub fn call() {
     // write some value
     pwasm_ethereum::write(&pwasm_std::types::H256::zero(), &[0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1]);
     // call another contract
-    pwasm_ethereum::call(0, &Address::zero(), pwasm_std::types::U256::zero(), &[], &mut [] );
+    pwasm_ethereum::call(0, &Address::zero(), pwasm_std::types::U256::zero(), &[], &mut [] ).unwrap();
     // delegate call another contract (under the hood this version of call_code
     // uses delgate call).
     pwasm_ethereum::gas_left();
     pwasm_ethereum::sender();
 
     // An example syscall (empty input and output)
-    cap9_syscall(&[], &mut []);
+    cap9_syscall(&[], &mut []).unwrap();
 
-    pwasm_ethereum::ret(&b"result"[..]);
     let mut endpoint = contract::ExampleContract1Endpoint::new(contract::ExampleContract1{});
     pwasm_ethereum::ret(&endpoint.dispatch(&pwasm_ethereum::input()));
 }

--- a/kernel-ewasm/cap9-std/examples/writer_test.rs
+++ b/kernel-ewasm/cap9-std/examples/writer_test.rs
@@ -55,7 +55,7 @@ pub mod writer {
         }
 
         fn writeNum(&mut self, cap_idx: U256, key: U256, val: U256) {
-            cap9_std::raw_proc_write(cap_idx.as_u32() as u8, &key.into(), &val.into()).expect("Invalid Cap Id");
+            cap9_std::raw_proc_write(cap_idx.as_u32() as u8, &key.into(), &val.into());
         }
     }
 }

--- a/kernel-ewasm/cap9-std/examples/writer_test.rs
+++ b/kernel-ewasm/cap9-std/examples/writer_test.rs
@@ -55,7 +55,7 @@ pub mod writer {
         }
 
         fn writeNum(&mut self, cap_idx: U256, key: U256, val: U256) {
-            cap9_std::raw_proc_write(cap_idx.as_u32() as u8, &key.into(), &val.into());
+            cap9_std::raw_proc_write(cap_idx.as_u32() as u8, &key.into(), &val.into()).unwrap();
         }
     }
 }

--- a/kernel-ewasm/cap9-std/examples/writer_test.rs
+++ b/kernel-ewasm/cap9-std/examples/writer_test.rs
@@ -33,6 +33,8 @@ pub mod writer {
         #[constant]
         fn getNum(&mut self, key: U256) -> U256;
 
+        fn writeNumDirect(&mut self, key: U256, val: U256);
+
         fn writeNum(&mut self, cap_idx: U256, key: U256, val: U256);
 
     }
@@ -45,6 +47,11 @@ pub mod writer {
 
         fn getNum(&mut self, key: U256) -> U256 {
             pwasm_ethereum::read(&key.into()).into()
+        }
+
+        // Write to storage without going through the kernel or cap system
+        fn writeNumDirect(&mut self, key: U256, val: U256) {
+            pwasm_ethereum::write(&key.into(), &val.into());
         }
 
         fn writeNum(&mut self, cap_idx: U256, key: U256, val: U256) {

--- a/kernel-ewasm/cap9-std/src/lib.rs
+++ b/kernel-ewasm/cap9-std/src/lib.rs
@@ -80,6 +80,22 @@ pub fn extcodecopy(address: &Address) -> pwasm_std::Vec<u8> {
     }
 }
 
+/// This function is the rough shape of a syscall. It's only purpose is to force
+/// the inclusion/import of all the necessay Ethereum functions and prevent them
+/// from being deadcode eliminated. As part of this, it is also necessary to
+/// pass wasm-build "dummy_syscall" as a public api parameter, to ensure that it
+/// is preserved.
+///
+/// TODO: this is something we would like to not have to do
+#[no_mangle]
+fn dummy_syscall() {
+    pwasm_ethereum::gas_left();
+    pwasm_ethereum::sender();
+    unsafe {
+        external::dcall(0,0 as *const u8, 0 as *const u8, 0, 0 as *mut u8, 0);
+    }
+}
+
 /// This is to replace pwasm_ethereum::call_code, and uses [`cap9_syscall_low`]: fn.cap9_syscall_low.html
 /// underneath instead of dcall. This is a slightly higher level abstraction
 /// over cap9_syscall_low that uses Result types and the like. This is by no

--- a/kernel-ewasm/cap9-std/src/lib.rs
+++ b/kernel-ewasm/cap9-std/src/lib.rs
@@ -35,6 +35,9 @@ pub mod external {
                 result_len: u32,
         ) -> i32;
 
+        pub fn result_length() -> i32;
+        pub fn fetch_result( dest: *mut u8);
+
         /// This extern marks an external import that we get from linking or
         /// environment. Usually this would be something pulled in from the Ethereum
         /// environement, but in this case we will use a later stage in the build
@@ -78,6 +81,23 @@ pub fn extcodecopy(address: &Address) -> pwasm_std::Vec<u8> {
             data
         }
     }
+}
+
+/// Allocates and requests [`call`] return data (result)
+pub fn result() -> pwasm_std::Vec<u8> {
+	let len = unsafe { external::result_length() };
+
+	match len {
+		0 => pwasm_std::Vec::new(),
+		non_zero => {
+			let mut data = pwasm_std::Vec::with_capacity(non_zero as usize);
+			unsafe {
+				data.set_len(non_zero as usize);
+				external::fetch_result(data.as_mut_ptr());
+			}
+			data
+		}
+	}
 }
 
 /// This function is the rough shape of a syscall. It's only purpose is to force

--- a/kernel-ewasm/cap9-std/src/lib.rs
+++ b/kernel-ewasm/cap9-std/src/lib.rs
@@ -176,7 +176,10 @@ pub fn cap9_syscall(input: &[u8], result: &mut [u8]) -> Result<(), Error> {
 
 pub fn raw_proc_write(cap_index: u8, key: &[u8; 32], value: &[u8; 32]) -> Result<(), Error> {
     let mut input = Vec::with_capacity(1 + 1 + 32 + 32);
-    let syscall = SysCallAction::Write(WriteCall{key: key.into(), value: value.into()});
+    let syscall = SysCall {
+        cap_index,
+        action: SysCallAction::Write(WriteCall{key: key.into(), value: value.into()}),
+    };
     syscall.serialize(&mut input).unwrap();
     let mut result = Vec::with_capacity(32);
     result.resize(32,0);
@@ -265,10 +268,6 @@ impl Serialize for WriteCall {
     type Error = io::Error;
 
     fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
-        // Write syscall type
-        writer.write(&[0x7])?;
-        // Write cap index
-        writer.write(&[0x00])?;
         // Write key
         self.key.serialize(writer)?;
         // Write value
@@ -291,7 +290,10 @@ mod tests {
         let value: U256 = U256::zero();
         let mut buffer = Vec::with_capacity(1 + 1 + 32 + 32);
 
-        let syscall = SysCallAction::Write(WriteCall{key: key.into(), value: value.into()});
+        let syscall = SysCall {
+            cap_index: 0,
+            action: SysCallAction::Write(WriteCall{key: key.into(), value: value.into()})
+        };
         syscall.serialize(&mut buffer).unwrap();
         let expected: &[u8] = &[0x7, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,0x00,0x00,

--- a/kernel-ewasm/cap9-std/src/proc_table/mod.rs
+++ b/kernel-ewasm/cap9-std/src/proc_table/mod.rs
@@ -283,7 +283,8 @@ pub fn set_entry_proc_id(key: ProcedureKey) -> Result<(), InvalidProcId> {
 
 /// Set Current Procedure Id
 pub fn set_current_proc_id(key: ProcedureKey) -> Result<(), InvalidProcId> {
-    if key == [0; 24] {return Err(InvalidProcId);}
+    // Sometime we want to set this value to null.
+    // if key == [0; 24] {return Err(InvalidProcId);}
     let mut result = [0u8; 32];
     result[8..].copy_from_slice(&key);
     pwasm_ethereum::write(&H256(KERNEL_CURRENT_PROC_PTR), &result);

--- a/kernel-ewasm/cap9-test/src/lib.rs
+++ b/kernel-ewasm/cap9-test/src/lib.rs
@@ -31,3 +31,20 @@ pub extern fn cap9_syscall_low(input_ptr: *const u8, input_len: u32, result_ptr:
 pub extern fn gasleft() -> i64 {
     panic!("gasleft not available");
 }
+
+#[no_mangle]
+pub extern fn call_code() -> i64 {
+    panic!("call_code not available");
+}
+
+
+#[no_mangle]
+pub extern fn result_length() -> i64 {
+    panic!("result_length not available");
+}
+
+
+#[no_mangle]
+pub extern fn fetch_result() -> i64 {
+    panic!("fetch_result not available");
+}

--- a/kernel-ewasm/scripts/build.bat
+++ b/kernel-ewasm/scripts/build.bat
@@ -18,5 +18,7 @@ wasm-build --target=wasm32-unknown-unknown .\target kernel-ewasm
 COPY .\target\wasm32-unknown-unknown\release\examples\*_test.wasm .\target\wasm32-unknown-unknown\release
 wasm-build --target=wasm32-unknown-unknown .\target cap9-kernel
 
+cargo run --package cap9-build -- build-proc .\target\wasm32-unknown-unknown\release\writer_test.wasm .\target\wasm32-unknown-unknown\release\writer_test.wasm
 wasm-build --target=wasm32-unknown-unknown .\target writer_test
+cargo run --package cap9-build -- build-proc .\target\wasm32-unknown-unknown\release\entry_test.wasm .\target\wasm32-unknown-unknown\release\entry_test.wasm
 wasm-build --target=wasm32-unknown-unknown .\target entry_test

--- a/kernel-ewasm/scripts/build.bat
+++ b/kernel-ewasm/scripts/build.bat
@@ -8,6 +8,9 @@ set contract_name=cap9_kernel
 cargo build --examples --target wasm32-unknown-unknown --release --features std
 
 cargo build --release --target wasm32-unknown-unknown --no-default-features --features "panic_with_msg"
+cd cap9-kernel
+cargo build --release --target wasm32-unknown-unknown --no-default-features --features "panic_with_msg"
+cd ..
 cap9-build set-mem --pages 3 .\target\wasm32-unknown-unknown\release\%contract_name%.wasm .\target\wasm32-unknown-unknown\release\%contract_name%.wasm
 cargo run --package cap9-build -- set-mem --pages 3 .\target\wasm32-unknown-unknown\release\%contract_name%.wasm .\target\wasm32-unknown-unknown\release\%contract_name%.wasm
 wasm-build --target=wasm32-unknown-unknown .\target kernel-ewasm

--- a/kernel-ewasm/scripts/build.sh
+++ b/kernel-ewasm/scripts/build.sh
@@ -11,5 +11,7 @@ cargo run --package cap9-build -- set-mem --pages 3 ./target/wasm32-unknown-unkn
 cp ./target/wasm32-unknown-unknown/release/examples/*_test.wasm ./target/wasm32-unknown-unknown/release
 wasm-build --target=wasm32-unknown-unknown ./target cap9-kernel
 
+cargo run --package cap9-build -- build-proc ./target/wasm32-unknown-unknown/release/writer_test.wasm ./target/wasm32-unknown-unknown/release/writer_test.wasm
 wasm-build --target=wasm32-unknown-unknown ./target writer_test
+cargo run --package cap9-build -- build-proc ./target/wasm32-unknown-unknown/release/entry_test.wasm ./target/wasm32-unknown-unknown/release/entry_test.wasm
 wasm-build --target=wasm32-unknown-unknown ./target entry_test

--- a/kernel-ewasm/scripts/build.sh
+++ b/kernel-ewasm/scripts/build.sh
@@ -2,9 +2,12 @@
 rustup target add wasm32-unknown-unknown
 cargo install pwasm-utils-cli --bin wasm-build --version 0.6.0
 
-cargo build --release --target wasm32-unknown-unknown --no-default-features --features "panic_with_msg"
 cargo build --examples --target wasm32-unknown-unknown --release --features std
 
+cargo build --release --target wasm32-unknown-unknown --no-default-features --features "panic_with_msg"
+pushd cap9-kernel
+cargo build --release --target wasm32-unknown-unknown --no-default-features --features "panic_with_msg"
+popd
 cargo run --package cap9-build -- set-mem --pages 3 ./target/wasm32-unknown-unknown/release/cap9_kernel.wasm ./target/wasm32-unknown-unknown/release/cap9_kernel.wasm
 
 # Copy Examples

--- a/kernel-ewasm/tests/instance.ts
+++ b/kernel-ewasm/tests/instance.ts
@@ -46,6 +46,17 @@ describe('Kernel', function () {
                 assert.strictEqual(currentCapLen, 1, `There should be 1 of type: ${CAP_TYPE[captype]}`)
             }
         })
+
+        it('should panic properly', async function () {
+            this.timeout(20000);
+            let kernel = await newKernelInstance("init", "0xc1912fee45d61c87cc5ea59dae31190fffff232d");
+            try {
+                await kernel.contract.methods.panic().call();
+                assert(false, "method should panic");
+            } catch (e) {
+                assert(e.message.includes("test-panic"), "the message 'test-panic' should be included in the output");
+            }
+        })
     })
 
     describe('validator', function () {

--- a/kernel-ewasm/tests/syscalls/write.ts
+++ b/kernel-ewasm/tests/syscalls/write.ts
@@ -4,7 +4,8 @@ const assert = require('assert')
 import { newKernelInstance, web3, createAccount, KernelInstance, deployContract } from '../utils'
 
 
-describe.skip('Write Syscall', function () {
+describe('Write Syscall', function () {
+    this.timeout(40_000);
     describe('#getNum', function () {
         it('should return correct value', async function () {
             const accounts = await web3.eth.personal.getAccounts()
@@ -18,7 +19,9 @@ describe.skip('Write Syscall', function () {
 
             {
                 let raw_data = newProc.methods.writeNum(0, 0, 1).encodeABI()
-                let result = await web3.eth.call({
+                // This needs to be a "sendTransaction" instead of a "call" in
+                // order for it to be able to change state on the chain.
+                let result = await web3.eth.sendTransaction({
                     from: accounts[0],
                     data: raw_data
                 })
@@ -34,4 +37,3 @@ describe.skip('Write Syscall', function () {
         })
     })
 })
-

--- a/kernel-ewasm/tests/syscalls/write.ts
+++ b/kernel-ewasm/tests/syscalls/write.ts
@@ -2,7 +2,8 @@ const Web3 = require('web3')
 const assert = require('assert')
 const fs = require('fs')
 
-import { newKernelInstance, web3, createAccount, KernelInstance, deployContract } from '../utils'
+import { newKernelInstance, web3, createAccount, KernelInstance, deployContract, normalize } from '../utils'
+import { notEqual } from 'assert';
 
 
 describe('Write Syscall', function () {
@@ -31,7 +32,7 @@ describe('Write Syscall', function () {
             // back.
 
             // This is the key that we will be modifying in storage.
-            const key = 0;
+            const key = "0xdeadbeef";
 
             // Retrieve the original value.
             const original_value = await kernel_asWriter.methods.getNum(key).call();
@@ -60,7 +61,8 @@ describe('Write Syscall', function () {
             // back.
 
             // This is the key that we will be modifying in storage.
-            const key = 0;
+            const key = "0xdeadbeef";
+            const value = "0xfee";
             // This is the index of the capability (in the procedures capability
             // list) that we will be using to perform the writes.
             const cap_index = 0;
@@ -71,12 +73,12 @@ describe('Write Syscall', function () {
 
             // Write a new value (1) into the storage at 'key' using the cap at
             // 'cap_index'
-            await kernel_asWriter.methods.writeNumDirect(key, 1).send();
+            await kernel_asWriter.methods.writeNumDirect(key, value).send();
             // await kernel_asWriter.methods.writeNum(cap_index, key, 1).call();
 
             // Retrive the value again and ensure that it has changed.
             const new_value = await kernel_asWriter.methods.getNum(key).call();
-            assert.strictEqual(new_value.toNumber(), 1, "The new value should be 1");
+            assert.strictEqual(normalize(new_value), normalize(value), `The new value should be ${value}`);
         })
         it('should modify the value via the kernel', async function () {
             const accounts = await web3.eth.personal.getAccounts()
@@ -101,7 +103,8 @@ describe('Write Syscall', function () {
             // back.
 
             // This is the key that we will be modifying in storage.
-            const key = 0;
+            const key = "0xdeadbeef";
+            const value = "0xfee";
             // This is the index of the capability (in the procedures capability
             // list) that we will be using to perform the writes.
             const cap_index = 0;
@@ -112,11 +115,11 @@ describe('Write Syscall', function () {
 
             // Write a new value (1) into the storage at 'key' using the cap at
             // 'cap_index'
-            await kernel_asWriter.methods.writeNum(cap_index, key, 1).send();
+            await kernel_asWriter.methods.writeNum(cap_index, key, value).send();
 
             // Retrive the value again and ensure that it has changed.
             const new_value = await kernel_asWriter.methods.getNum(key).call();
-            assert.strictEqual(new_value.toNumber(), 1, "The new value should be 1");
+            assert.strictEqual(normalize(new_value), normalize(value), `The new value should be ${value}`);
         })
     })
 })

--- a/kernel-ewasm/tests/syscalls/write.ts
+++ b/kernel-ewasm/tests/syscalls/write.ts
@@ -5,9 +5,9 @@ import { newKernelInstance, web3, createAccount, KernelInstance, deployContract 
 
 
 describe('Write Syscall', function () {
-    this.timeout(40_000);
+    this.timeout(10_000);
     describe('#getNum', function () {
-        it('should return correct value', async function () {
+        it('should return the initial value', async function () {
             const accounts = await web3.eth.personal.getAccounts()
 
             let newProc = await deployContract("writer_test", "TestWriterInterface");
@@ -20,23 +20,110 @@ describe('Write Syscall', function () {
             let kernel_asWriter = newProc.clone();
             kernel_asWriter.address = kernel.contract.address;
 
-            {
-                let raw_data = newProc.methods.writeNum(0, 0, 1).encodeABI()
-                // This needs to be a "sendTransaction" instead of a "call" in
-                // order for it to be able to change state on the chain.
-                let result = await web3.eth.sendTransaction({
-                    from: accounts[0],
-                    data: raw_data
-                })
-            }
+            // The writer_test procedure is now set as the entry procedure. In
+            // order to execute this procedure, we first have to put the kernel
+            // into "entry procedure mode".
+            const toggle1 = await kernel.contract.methods.get_mode().call();
+            assert.strictEqual(toggle1, 0, "The kernel should be in test mode (0)");
+            await kernel.contract.methods.toggle_syscall().send();
+            // Once we have toggled entry procedure on, we have no way to switch
+            // back.
 
-            let raw_data = newProc.methods.getNum(0).encodeABI()
-            let result = await web3.eth.call({
-                from: accounts[0],
-                data: raw_data
-            })
+            // This is the key that we will be modifying in storage.
+            const key = 0;
 
-            assert.equal(result, 1);
+            // Retrieve the original value.
+            const original_value = await newProc.methods.getNum(key).call();
+            assert.strictEqual(original_value.toNumber(), 0, "The original value should be 0");
+        })
+        it('should modify the value directly', async function () {
+            const accounts = await web3.eth.personal.getAccounts()
+
+            let newProc = await deployContract("writer_test", "TestWriterInterface");
+            let kernel = await newKernelInstance("init", newProc.address);
+
+            // Here we make a copy of the "writer_test" contract interface, but
+            // change the address so that it's pointing at the kernel. This
+            // means the web3 library will send a message crafted to be read by
+            // the writer contract directly to the kernel.
+            let kernel_asWriter = newProc.clone();
+            kernel_asWriter.address = kernel.contract.address;
+
+            // The writer_test procedure is now set as the entry procedure. In
+            // order to execute this procedure, we first have to put the kernel
+            // into "entry procedure mode".
+            const toggle1 = await kernel.contract.methods.get_mode().call();
+            assert.strictEqual(toggle1, 0, "The kernel should be in test mode (0)");
+            await kernel.contract.methods.toggle_syscall().send();
+            // Once we have toggled entry procedure on, we have no way to switch
+            // back.
+
+            // This is the key that we will be modifying in storage.
+            const key = 0;
+            // This is the index of the capability (in the procedures capability
+            // list) that we will be using to perform the writes.
+            const cap_index = 0;
+
+            // Retrieve the original value.
+            const original_value = await newProc.methods.getNum(key).call();
+            assert.strictEqual(original_value.toNumber(), 0, "The original value should be 0");
+
+            // Write a new value (1) into the storage at 'key'
+            await newProc.methods.writeNumDirect(key, 1).send();
+
+            // Retrive the value again and ensure that it has changed.
+            const new_value = await newProc.methods.getNum(key).call();
+            assert.strictEqual(new_value.toNumber(), 1, "The new value should be 1");
+        })
+        it.skip('should modify the value via the kernel', async function () {
+            const accounts = await web3.eth.personal.getAccounts()
+
+            let newProc = await deployContract("writer_test", "TestWriterInterface");
+            let kernel = await newKernelInstance("init", newProc.address);
+
+            // Here we make a copy of the "writer_test" contract interface, but
+            // change the address so that it's pointing at the kernel. This
+            // means the web3 library will send a message crafted to be read by
+            // the writer contract directly to the kernel.
+            let kernel_asWriter = newProc.clone();
+            kernel_asWriter.address = kernel.contract.address;
+
+
+            const kernelAddress = kernel.contract.options.address;
+            const code_size = await kernel.contract.methods.get_code_size(newProc.address).call();
+            const code_hex = await kernel.contract.methods.code_copy(newProc.address).call();
+            const code = Buffer.from(web3.utils.hexToBytes(code_hex));
+            // console.log(code)
+            fs.writeFile("t.wasm", code, "binary", ()=>{});
+            // assert.strictEqual(code_size, code.length, "The code length should be as given by EXTCODESIZE");
+
+
+            // The writer_test procedure is now set as the entry procedure. In
+            // order to execute this procedure, we first have to put the kernel
+            // into "entry procedure mode".
+            const toggle1 = await kernel.contract.methods.get_mode().call();
+            assert.strictEqual(toggle1, 0, "The kernel should be in test mode (0)");
+            await kernel.contract.methods.toggle_syscall().send();
+            // Once we have toggled entry procedure on, we have no way to switch
+            // back.
+
+            // This is the key that we will be modifying in storage.
+            const key = 0;
+            // This is the index of the capability (in the procedures capability
+            // list) that we will be using to perform the writes.
+            const cap_index = 0;
+
+            // Retrieve the original value.
+            const original_value = await newProc.methods.getNum(key).call();
+            assert.strictEqual(original_value.toNumber(), 0, "The original value should be 0");
+
+            // Write a new value (1) into the storage at 'key' using the cap at
+            // 'cap_index'
+            // await newProc.methods.writeNum(cap_index, key, 1).send();
+
+            // Retrive the value again and ensure that it has changed.
+            // const new_value = await newProc.methods.getNum(key).call();
+            // assert.strictEqual(new_value.toNumber(), 1, "The new value should be 1");
         })
     })
 })

--- a/kernel-ewasm/tests/syscalls/write.ts
+++ b/kernel-ewasm/tests/syscalls/write.ts
@@ -78,7 +78,7 @@ describe('Write Syscall', function () {
             const new_value = await kernel_asWriter.methods.getNum(key).call();
             assert.strictEqual(new_value.toNumber(), 1, "The new value should be 1");
         })
-        it.skip('should modify the value via the kernel', async function () {
+        it('should modify the value via the kernel', async function () {
             const accounts = await web3.eth.personal.getAccounts()
 
             let newProc = await deployContract("writer_test", "TestWriterInterface");
@@ -112,7 +112,7 @@ describe('Write Syscall', function () {
 
             // Write a new value (1) into the storage at 'key' using the cap at
             // 'cap_index'
-            await kernel_asWriter.methods.writeNum(cap_index, key, 1).call();
+            await kernel_asWriter.methods.writeNum(cap_index, key, 1).send();
 
             // Retrive the value again and ensure that it has changed.
             const new_value = await kernel_asWriter.methods.getNum(key).call();

--- a/kernel-ewasm/tests/syscalls/write.ts
+++ b/kernel-ewasm/tests/syscalls/write.ts
@@ -94,7 +94,7 @@ describe('Write Syscall', function () {
             const code_hex = await kernel.contract.methods.code_copy(newProc.address).call();
             const code = Buffer.from(web3.utils.hexToBytes(code_hex));
             // console.log(code)
-            fs.writeFile("t.wasm", code, "binary", ()=>{});
+            // fs.writeFile("t.wasm", code, "binary", ()=>{});
             // assert.strictEqual(code_size, code.length, "The code length should be as given by EXTCODESIZE");
 
 

--- a/kernel-ewasm/tests/syscalls/write.ts
+++ b/kernel-ewasm/tests/syscalls/write.ts
@@ -7,7 +7,7 @@ import { newKernelInstance, web3, createAccount, KernelInstance, deployContract 
 
 describe('Write Syscall', function () {
     this.timeout(40_000);
-    describe('#getNum', function () {
+    describe('#get/writeNum', function () {
         it('should return the initial value', async function () {
             const accounts = await web3.eth.personal.getAccounts()
 

--- a/kernel-ewasm/tests/syscalls/write.ts
+++ b/kernel-ewasm/tests/syscalls/write.ts
@@ -121,5 +121,51 @@ describe('Write Syscall', function () {
             const new_value = await kernel_asWriter.methods.getNum(key).call();
             assert.strictEqual(normalize(new_value), normalize(value), `The new value should be ${value}`);
         })
+        it('should fail to modify the value via the kernel with the wrong cap index', async function () {
+            const accounts = await web3.eth.personal.getAccounts()
+
+            let newProc = await deployContract("writer_test", "TestWriterInterface");
+            let kernel = await newKernelInstance("init", newProc.address);
+
+            // Here we make a copy of the "writer_test" contract interface, but
+            // change the address so that it's pointing at the kernel. This
+            // means the web3 library will send a message crafted to be read by
+            // the writer contract directly to the kernel.
+            let kernel_asWriter = newProc.clone();
+            kernel_asWriter.address = kernel.contract.address;
+
+            // The writer_test procedure is now set as the entry procedure. In
+            // order to execute this procedure, we first have to put the kernel
+            // into "entry procedure mode".
+            const toggle1 = await kernel.contract.methods.get_mode().call();
+            assert.strictEqual(toggle1, 0, "The kernel should be in test mode (0)");
+            await kernel.contract.methods.toggle_syscall().send();
+            // Once we have toggled entry procedure on, we have no way to switch
+            // back.
+
+            // This is the key that we will be modifying in storage.
+            const key = "0xdeadbeef";
+            const value = "0xfee";
+            // This is the index of the capability (in the procedures capability
+            // list) that we will be using to perform the writes.
+            const cap_index = 1;
+
+            // Retrieve the original value.
+            const original_value = await kernel_asWriter.methods.getNum(key).call();
+            assert.strictEqual(original_value.toNumber(), 0, "The original value should be 0");
+
+            // Write a new value (1) into the storage at 'key' using the cap at
+            // 'cap_index'. This should fail.
+            try {
+                await kernel_asWriter.methods.writeNum(cap_index, key, value).send();
+                assert(false, "This should fail");
+            } catch (e) {
+
+            }
+
+            // Retrive the value again and ensure that it has changed.
+            const new_value = await kernel_asWriter.methods.getNum(key).call();
+            assert.strictEqual(normalize(new_value), normalize(0), `The new value should still be ${0}`);
+        })
     })
 })

--- a/kernel-ewasm/tests/syscalls/write.ts
+++ b/kernel-ewasm/tests/syscalls/write.ts
@@ -13,9 +13,12 @@ describe('Write Syscall', function () {
             let newProc = await deployContract("writer_test", "TestWriterInterface");
             let kernel = await newKernelInstance("init", newProc.address);
 
+            // Here we make a copy of the "writer_test" contract interface, but
+            // change the address so that it's pointing at the kernel. This
+            // means the web3 library will send a message crafted to be read by
+            // the writer contract directly to the kernel.
             let kernel_asWriter = newProc.clone();
             kernel_asWriter.address = kernel.contract.address;
-
 
             {
                 let raw_data = newProc.methods.writeNum(0, 0, 1).encodeABI()

--- a/kernel-ewasm/tests/utils/index.ts
+++ b/kernel-ewasm/tests/utils/index.ts
@@ -279,3 +279,9 @@ export async function newKernelInstance(proc_key: string, proc_address: string, 
     contract.address = contract_addr;
     return new KernelInstance(contract);
 }
+
+
+// Given a web3 value, normalize it so we can compare easily.
+export function normalize(value) {
+    return web3.utils.toHex(web3.utils.toBN(value))
+}

--- a/kernel-ewasm/tests/utils/index.ts
+++ b/kernel-ewasm/tests/utils/index.ts
@@ -240,7 +240,7 @@ export async function deployContract(file_name: string, abi_name: string): Promi
     const Contract = new web3.eth.Contract(abi, null, { data: codeHex, from: account, transactionConfirmationBlocks: 1 } as any);
     const DeploymentTx = Contract.deploy({ data: codeHex });
 
-    await web3.eth.personal.unlockAccount(accounts[0], "user", null);
+    await web3.eth.personal.unlockAccount(accounts[0], DEFAULT_ACCOUNT.PASSWORD, null);
     let gas = await DeploymentTx.estimateGas();
     let contract_tx = DeploymentTx.send({ gasLimit: gas, from: account } as any);
     let tx_hash: string = await new Promise((res, rej) => contract_tx.on('transactionHash', res).on('error', rej));

--- a/kernel-ewasm/validator/src/lib.rs
+++ b/kernel-ewasm/validator/src/lib.rs
@@ -12,9 +12,9 @@ extern crate alloc;
 mod func;
 mod import_entry;
 mod instructions;
-mod io;
+pub mod io;
 mod primitives;
-mod serialization;
+pub mod serialization;
 mod types;
 use self::serialization::Deserialize;
 

--- a/kernel-ewasm/validator/src/types.rs
+++ b/kernel-ewasm/validator/src/types.rs
@@ -5,6 +5,7 @@ use crate::io;
 use super::{Deserialize, VarUint7, VarInt7, CountedList,
     VarUint32};
 use crate::serialization::{Error};
+use pwasm_std::types::U256;
 
 /// Type definition in types section. Currently can be only of the function type.
 #[derive(Debug, Clone, PartialEq, Hash, Eq)]
@@ -168,5 +169,26 @@ impl Deserialize for TableElementType {
             -0x10 => Ok(TableElementType::AnyFunc),
             _ => Err(Error::UnknownTableElementType(val.into())),
         }
+    }
+}
+
+impl Deserialize for u8 {
+    type Error = io::Error;
+
+    fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+        let mut u8buf = [0u8; 1];
+        reader.read(&mut u8buf)?;
+        Ok(u8buf[0])
+    }
+}
+
+impl Deserialize for U256 {
+    type Error = io::Error;
+
+    fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+        let mut u8buf = [0u8; 32];
+        // TODO: check that enough bytes were read
+        reader.read(&mut u8buf)?;
+        Ok(u8buf.into())
     }
 }

--- a/kernel-ewasm/validator/src/types.rs
+++ b/kernel-ewasm/validator/src/types.rs
@@ -4,7 +4,7 @@ use pwasm_std::vec::Vec;
 use crate::io;
 use super::{Deserialize, VarUint7, VarInt7, CountedList,
     VarUint32};
-use crate::serialization::{Error};
+use crate::serialization::{Error, Serialize};
 use pwasm_std::types::U256;
 
 /// Type definition in types section. Currently can be only of the function type.
@@ -190,5 +190,18 @@ impl Deserialize for U256 {
         // TODO: check that enough bytes were read
         reader.read(&mut u8buf)?;
         Ok(u8buf.into())
+    }
+}
+
+
+impl Serialize for U256 {
+    type Error = io::Error;
+
+    fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
+        let mut bytes: Vec<u8> = Vec::new();
+        bytes.resize(32,0);
+        self.to_big_endian(bytes.as_mut_slice());
+        writer.write(&bytes)?;
+        Ok(())
     }
 }

--- a/kernel-ewasm/wasm-dev-chain.json
+++ b/kernel-ewasm/wasm-dev-chain.json
@@ -5,6 +5,7 @@
     },
     "params": {
         "wasmActivationTransition": "0x00",
+        "kip6Transition": "0x0",
         "eip658Transition": "0x01",
         "gasLimitBoundDivisor": "0x0400",
         "accountStartNonce": "0x0",

--- a/run-parity.bat
+++ b/run-parity.bat
@@ -1,2 +1,2 @@
 ..\parity-ethereum\target\debug\parity  --config dev --chain ./kernel-ewasm/wasm-dev-chain.json db kill
-..\parity-ethereum\target\debug\parity  --config dev --chain ./kernel-ewasm/wasm-dev-chain.json --jsonrpc-apis=all --ws-apis=all --reseal-min-period 0
+..\parity-ethereum\target\debug\parity  --config dev --chain ./kernel-ewasm/wasm-dev-chain.json --jsonrpc-apis=all --ws-apis=all --reseal-min-period 0 --geth

--- a/run-parity.bat
+++ b/run-parity.bat
@@ -1,2 +1,0 @@
-..\parity-ethereum\target\debug\parity  --config dev --chain ./kernel-ewasm/wasm-dev-chain.json db kill
-..\parity-ethereum\target\debug\parity  --config dev --chain ./kernel-ewasm/wasm-dev-chain.json --jsonrpc-apis=all --ws-apis=all --reseal-min-period 0 --geth


### PR DESCRIPTION
This implements the `WRITE` syscall as per #140. This does not currently perform any checking of capabilities, but does include many lower level changes to get syscalls working in general.