### PR TITLE
Check caps for WRITE syscalls

### DIFF
--- a/kernel-ewasm/cap9-std/examples/writer_test.rs
+++ b/kernel-ewasm/cap9-std/examples/writer_test.rs
@@ -23,6 +23,8 @@ pub mod writer {
     use pwasm_ethereum;
     use pwasm_abi_derive::eth_abi;
     use cap9_std;
+    // use cap9_std::proc_table::*;
+    use cap9_std::proc_table::cap::*;
 
     #[eth_abi(TestWriterEndpoint, KernelClient)]
     pub trait TestWriterInterface {
@@ -36,6 +38,8 @@ pub mod writer {
         fn writeNumDirect(&mut self, key: U256, val: U256);
 
         fn writeNum(&mut self, cap_idx: U256, key: U256, val: U256);
+
+        fn getCap(&mut self, cap_type: U256, cap_index: U256) -> (U256, U256);
 
     }
 
@@ -56,6 +60,22 @@ pub mod writer {
 
         fn writeNum(&mut self, cap_idx: U256, key: U256, val: U256) {
             cap9_std::raw_proc_write(cap_idx.as_u32() as u8, &key.into(), &val.into()).unwrap();
+        }
+
+        fn getCap(&mut self, cap_type: U256, cap_index: U256) -> (U256, U256) {
+            // Get the key of the currently executing procedure.
+            let this_key: cap9_std::proc_table::ProcedureKey = cap9_std::proc_table::get_current_proc_id();
+            let cap = cap9_std::proc_table::get_proc_cap(this_key, cap_type.as_u32() as u8, cap_index.as_u32() as u8).unwrap();
+            match cap {
+                // ProcedureCall(ProcedureCallCap),
+                // ProcedureRegister(ProcedureRegisterCap),
+                // ProcedureDelete(ProcedureDeleteCap),
+                // ProcedureEntry(ProcedureEntryCap),
+                Capability::StoreWrite(StoreWriteCap {location, size}) => (location.into(), size.into()),
+                // Log(LogCap),
+                // AccountCall(AccountCallCap),
+                _ => panic!("wrong cap")
+            }
         }
     }
 }

--- a/kernel-ewasm/cap9-std/src/proc_table/mod.rs
+++ b/kernel-ewasm/cap9-std/src/proc_table/mod.rs
@@ -26,8 +26,8 @@ const KERNEL_ENTRY_PROC_PTR: [u8; 32] = [
     0, 0, 0, 0,
 ];
 
-type ProcedureKey = [u8; 24];
-type ProcedureIndex = [u8; 24];
+pub type ProcedureKey = [u8; 24];
+pub type ProcedureIndex = [u8; 24];
 
 pub mod cap;
 use cap::*;

--- a/kernel-ewasm/cap9-std/src/proc_table/mod.rs
+++ b/kernel-ewasm/cap9-std/src/proc_table/mod.rs
@@ -32,6 +32,8 @@ pub type ProcedureIndex = [u8; 24];
 pub mod cap;
 use cap::*;
 
+use crate::syscalls::*;
+
 pub struct ProcPointer(ProcedureKey);
 
 impl ProcPointer {
@@ -406,6 +408,12 @@ pub fn get_current_proc_id() -> ProcedureKey {
     let mut result = [0; 24];
     result.copy_from_slice(&proc_id[8..]);
     result
+}
+
+/// Given a syscall, get the relevant Capability for the current procedure.
+pub fn get_cap(syscall: &SysCall) -> Option<cap::Capability> {
+    let current_proc_key = get_current_proc_id();
+    get_proc_cap(current_proc_key, syscall.cap_type(), syscall.cap_index)
 }
 
 #[cfg(test)]

--- a/kernel-ewasm/cap9-std/src/syscalls.rs
+++ b/kernel-ewasm/cap9-std/src/syscalls.rs
@@ -1,0 +1,174 @@
+#![no_std]
+
+extern crate pwasm_abi;
+use pwasm_abi::types::*;
+use validator::io;
+use validator::serialization::{Deserialize, Serialize};
+
+/// Generic wasm error
+#[derive(Debug)]
+pub struct Error;
+
+use crate::proc_table;
+
+
+/// A full system call request, including the cap_index. This is permitted to
+/// access the procedure table as part of the environment.
+#[derive(Clone, Debug)]
+pub struct SysCall {
+    pub cap_index: u8,
+    pub action: SysCallAction,
+}
+
+impl SysCall {
+    pub fn cap_type(&self) -> u8 {
+        match &self.action {
+            SysCallAction::Write(_) => 0x7,
+        }
+    }
+
+    pub fn execute(&self) {
+        match self.action {
+            // WRITE syscall
+            SysCallAction::Write(WriteCall{key,value}) => {
+                let value_h256: H256 = value.into();
+                pwasm_ethereum::write(&key.into(), &value_h256.as_fixed_bytes());
+                pwasm_ethereum::ret(&[]);
+            },
+        }
+    }
+
+    /// Given a syscall, get the relevant Capability for the current procedure
+    /// and check that it is sufficient for the given syscall.
+    pub fn check_cap(&self) -> bool {
+        let current_proc_key = proc_table::get_current_proc_id();
+        match self.action {
+            // WRITE syscall
+            SysCallAction::Write(WriteCall{key,value:_}) => {
+                // Before we perform any actions, we want to check that this
+                // procedure has the correct capabilities. First we retrieve
+                // the capability indicated by cap_index and the syscall
+                // type.
+                if let Some(cap) = proc_table::get_proc_cap(current_proc_key, 0x7, self.cap_index.clone()) {
+                    if let proc_table::cap::Capability::StoreWrite(proc_table::cap::StoreWriteCap {location, size}) = cap {
+                        let location_u256: U256 = location.into();
+                        let size_u256: U256 = size.into();
+                        if (key >= location_u256) && (key <= (location_u256 + size_u256)) {
+                            return true;
+                        }
+                    }
+                }
+            },
+        }
+        false
+    }
+}
+
+
+impl Deserialize for SysCall {
+    type Error = io::Error;
+
+    fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+        let syscall_type = u8::deserialize(reader)?;
+        let cap_index = u8::deserialize(reader)?;
+        match syscall_type {
+            0x7 => {
+                Ok(SysCall {
+                    cap_index,
+                    action: SysCallAction::Write(WriteCall::deserialize(reader)?)
+                })
+            },
+            _ => panic!("unknown syscall"),
+        }
+    }
+}
+
+
+impl Serialize for SysCall {
+    type Error = io::Error;
+
+    fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
+        // Write syscall type
+        match self.action {
+            SysCallAction::Write(_) => writer.write(&[0x07])?
+        }
+        // Write cap index
+        writer.write(&[self.cap_index])?;
+        self.action.serialize(writer)?;
+        Ok(())
+    }
+}
+
+
+#[derive(Clone, Debug)]
+pub enum SysCallAction {
+    Write(WriteCall),
+}
+
+#[derive(Clone, Debug)]
+pub struct WriteCall {
+    pub key: U256,
+    pub value: U256,
+}
+
+impl Deserialize for WriteCall {
+    type Error = io::Error;
+
+    fn deserialize<R: io::Read>(reader: &mut R) -> Result<Self, Self::Error> {
+        let key: U256 = U256::deserialize(reader)?;
+        let value: U256 = U256::deserialize(reader)?;
+        Ok(WriteCall{key, value})
+    }
+}
+
+
+impl Serialize for SysCallAction {
+    type Error = io::Error;
+
+    fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
+        match self {
+            SysCallAction::Write(write_call) => {
+                write_call.serialize(writer)?;
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Serialize for WriteCall {
+    type Error = io::Error;
+
+    fn serialize<W: io::Write>(self, writer: &mut W) -> Result<(), Self::Error> {
+        // Write key
+        self.key.serialize(writer)?;
+        // Write value
+        self.value.serialize(writer)?;
+        Ok(())
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pwasm_abi::types::*;
+    use validator::io;
+    use validator::serialization::{Deserialize, Serialize};
+
+    #[test]
+    fn serialize_write() {
+        let key: U256 = U256::zero();
+        let value: U256 = U256::zero();
+        let mut buffer = Vec::with_capacity(1 + 1 + 32 + 32);
+
+        let syscall = SysCall {
+            cap_index: 0,
+            action: SysCallAction::Write(WriteCall{key: key.into(), value: value.into()})
+        };
+        syscall.serialize(&mut buffer).unwrap();
+        let expected: &[u8] = &[0x7, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,0x00,0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,0x00];
+        assert_eq!(buffer, expected);
+    }
+}

--- a/kernel-ewasm/tests/syscalls/write.ts
+++ b/kernel-ewasm/tests/syscalls/write.ts
@@ -2,7 +2,7 @@ const Web3 = require('web3')
 const assert = require('assert')
 const fs = require('fs')
 
-import { newKernelInstance, web3, createAccount, KernelInstance, deployContract, normalize } from '../utils'
+import { newKernelInstance, web3, createAccount, KernelInstance, deployContract, normalize, WriteCap, NewCap } from '../utils'
 import { notEqual } from 'assert';
 
 
@@ -80,11 +80,11 @@ describe('Write Syscall', function () {
             const new_value = await kernel_asWriter.methods.getNum(key).call();
             assert.strictEqual(normalize(new_value), normalize(value), `The new value should be ${value}`);
         })
-        it('should modify the value via the kernel', async function () {
-            const accounts = await web3.eth.personal.getAccounts()
+        it('should modify the value via the kernel, with correct cap', async function () {
+            const caps = [new NewCap(0, new WriteCap(0xdeadbeef, 2))];
 
             let newProc = await deployContract("writer_test", "TestWriterInterface");
-            let kernel = await newKernelInstance("init", newProc.address);
+            let kernel = await newKernelInstance("init", newProc.address, caps);
 
             // Here we make a copy of the "writer_test" contract interface, but
             // change the address so that it's pointing at the kernel. This
@@ -113,6 +113,11 @@ describe('Write Syscall', function () {
             const original_value = await kernel_asWriter.methods.getNum(key).call();
             assert.strictEqual(original_value.toNumber(), 0, "The original value should be 0");
 
+            // Check that we have the right cap at index 0
+            const write_cap = await kernel_asWriter.methods.getCap(0x7,0).call();
+            assert.strictEqual(normalize(write_cap[0]), normalize(key), "The base of the write cap should match the key");
+            assert.strictEqual(normalize(write_cap[1]), normalize(2), "The additional length of the write cap should be 2");
+
             // Write a new value (1) into the storage at 'key' using the cap at
             // 'cap_index'
             await kernel_asWriter.methods.writeNum(cap_index, key, value).send();
@@ -121,11 +126,11 @@ describe('Write Syscall', function () {
             const new_value = await kernel_asWriter.methods.getNum(key).call();
             assert.strictEqual(normalize(new_value), normalize(value), `The new value should be ${value}`);
         })
-        it('should fail to modify the value via the kernel with the wrong cap index', async function () {
-            const accounts = await web3.eth.personal.getAccounts()
+        it('should fail to modify the value via the kernel with the wrong cap', async function () {
+            const caps = [new NewCap(0, new WriteCap(0x8000, 2))];
 
             let newProc = await deployContract("writer_test", "TestWriterInterface");
-            let kernel = await newKernelInstance("init", newProc.address);
+            let kernel = await newKernelInstance("init", newProc.address, caps);
 
             // Here we make a copy of the "writer_test" contract interface, but
             // change the address so that it's pointing at the kernel. This
@@ -148,11 +153,16 @@ describe('Write Syscall', function () {
             const value = "0xfee";
             // This is the index of the capability (in the procedures capability
             // list) that we will be using to perform the writes.
-            const cap_index = 1;
+            const cap_index = 0;
 
             // Retrieve the original value.
             const original_value = await kernel_asWriter.methods.getNum(key).call();
             assert.strictEqual(original_value.toNumber(), 0, "The original value should be 0");
+
+            // Check that we have the right cap at index 0
+            const write_cap = await kernel_asWriter.methods.getCap(0x7,0).call();
+            assert.strictEqual(normalize(write_cap[0]), normalize(0x8000), "The base of the write cap should be 0x8000");
+            assert.strictEqual(normalize(write_cap[1]), normalize(2), "The additional length of the write cap should be 2");
 
             // Write a new value (1) into the storage at 'key' using the cap at
             // 'cap_index'. This should fail.


### PR DESCRIPTION
This also outlines a rough API for the checking and execution of syscalls. My only hesitation was that (as I've implemented it) the procedure table is assumed to be an always present part of the environment rather that passed around. Given that this is true (the storage is always there) and it allows us to write a very clean API, I think it's ok. As it stands the code in the kernel for handling syscalls is literally:

```rust
let syscall: SysCall = SysCall::deserialize(&mut input).unwrap();
let cap_ok = syscall.check_cap();
if cap_ok {
    syscall.execute();
}
```

Which I think is decent. The implementation of each capability check (which is inherently different) is handled under the `SysCall` type.