### PR TITLE
Fix link to build.sh

### DIFF
--- a/kernel-ewasm/README.md
+++ b/kernel-ewasm/README.md
@@ -43,7 +43,7 @@ chmod +x ./scripts/parity_install.sh
 # Enter Dir
 cd kernel-ewasm
 # Compile lib to ewasm then as pwasm contract
-./build.sh
+./scripts/build.sh
 ```
 
 ### Test


### PR DESCRIPTION
`build.sh` doesn't exist in ./kernel-ewasm but does in ./scripts, I assume that is what is meant to be called here.