### PR TITLE
--fat-db, not --fatdb

### DIFF
--- a/kernel-ewasm/README.md
+++ b/kernel-ewasm/README.md
@@ -66,7 +66,7 @@ cargo test --package cap9-kernel --features std
 parity  --config dev --chain ./wasm-dev-chain.json db kill
 
 # Run Parity Dev Chain in seperate shell
-parity  --config dev --chain ./wasm-dev-chain.json --jsonrpc-apis=all --ws-apis=all --reseal-min-period 0 --gasprice 0 --geth --fatdb=on
+parity  --config dev --chain ./wasm-dev-chain.json --jsonrpc-apis=all --ws-apis=all --reseal-min-period 0 --gasprice 0 --geth --fat-db=on
 
 # Setup Test Account (if not created)
 curl --data '{"jsonrpc":"2.0","method":"parity_newAccountFromPhrase","params":["user", "user"],"id":0}' -H "Content-Type: application/json" -X POST localhost:8545


### PR DESCRIPTION
Under integration tests - 

"--fatdb=on" did not work in the latest dev environment.  I assume it is the (working) "--fat-db=on".