### PR TITLE
Remove kernel's test interface.

### DIFF
--- a/kernel-ewasm/cap9-kernel/src/lib.rs
+++ b/kernel-ewasm/cap9-kernel/src/lib.rs
@@ -18,18 +18,10 @@ use cap9_std::syscalls::SysCall;
 
 use cap9_core::{Cursor, Deserialize};
 
-/// This is a temporary storage location for toggling
-const TEST_KERNEL_SYSCALL_TOGGLE_PTR: [u8; 32] = [
-    0xff, 0xff, 0xff, 0xff, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0,
-];
-
 type ProcedureKey = [u8; 24];
 
 pub mod kernel {
     use pwasm_abi::types::*;
-    use validator::{Validity, Module};
-    use pwasm_ethereum;
 
     use crate::proc_table;
     use crate::proc_table::cap;
@@ -41,20 +33,6 @@ pub mod kernel {
         /// The constructor set with Initial Entry Procedure
         #[payable]
         fn constructor(&mut self, _entry_proc_key: String, _entry_proc_address: Address, _cap_list: Vec<U256>);
-        /// Check if Procedure Contract is Valid
-        fn check_contract(&mut self, _to: Address) -> bool;
-        /// Get the size (in bytes) of another contract
-        fn get_code_size(&mut self, _to: Address) -> i32;
-        /// Copy the code of another contract into memory
-        fn code_copy(&mut self, _to: Address) -> pwasm_std::Vec<u8>;
-
-        /// Toggle Syscall Mode
-        /// (Forwards all calls to entry procedure)
-        ///
-        /// _Temporary for debugging purposes_
-        fn toggle_syscall(&mut self);
-
-        fn get_mode(&mut self) -> u32;
 
         fn panic(&mut self);
     }
@@ -78,66 +56,11 @@ pub mod kernel {
             proc_table::set_entry_proc_id(_entry_proc_key).unwrap();
         }
 
-        fn check_contract(&mut self, target: Address) -> bool {
-            // First we check if the target is the null address. If so we return
-            // false.
-            if target == H160::zero() {
-                false
-            } else {
-                // Next we get the code of the contract, using EXTCODECOPY under
-                // the hood.
-                let code: pwasm_std::Vec<u8> = self.code_copy(target);
-                Module::new(code.as_slice()).is_valid()
-            }
-        }
-
-        fn get_code_size(&mut self, to: Address) -> i32 {
-            super::extcodesize(&to)
-        }
-
-        fn code_copy(&mut self, to: Address) -> pwasm_std::Vec<u8> {
-            let mut code = super::extcodecopy(&to);
-            // TODO: FIXME: This is an awful hack. Without these two resize
-            // lines (which have no net effect) we hit an Unreachable trap in
-            // the WASM code. Jake's hypothesis is that these two lines trigger
-            // a reallocation of some kind (of the vector) that side-steps
-            // whatever issue is occuring.
-            code.resize(code.len()-1,0);
-            code.resize(code.len()+1,0);
-            code
-        }
-
-        // fn get_cap_type_len(&mut self, _proc_key: String, _cap_type: U256) -> U256 {
-        //     let _proc_key = {
-        //         let byte_key = _proc_key.as_bytes();
-        //         let len = byte_key.len();
-        //         let mut output = [0u8; 24];
-        //         output[..len].copy_from_slice(byte_key);
-        //         output
-        //     };
-
-        //     U256::from(proc_table::get_proc_cap_list_len(_proc_key, _cap_type.as_u32() as u8))
-        // }
-
-        fn toggle_syscall(&mut self) {
-            toggle_syscall();
-        }
-
-        fn get_mode(&mut self) -> u32 {
-            let current_val = pwasm_ethereum::read(&H256(super::TEST_KERNEL_SYSCALL_TOGGLE_PTR));
-            current_val[0] as u32
-        }
-
         fn panic(&mut self) {
             panic!("test-panic")
         }
     }
 
-    pub fn toggle_syscall() {
-        let mut current_val = pwasm_ethereum::read(&H256(super::TEST_KERNEL_SYSCALL_TOGGLE_PTR));
-        current_val[0] = if current_val[0] == 0 { 1 } else { 0 };
-        pwasm_ethereum::write(&H256(super::TEST_KERNEL_SYSCALL_TOGGLE_PTR), &current_val);
-    }
 }
 
 
@@ -146,71 +69,50 @@ use pwasm_abi::eth::EndpointInterface;
 
 #[no_mangle]
 pub fn call() {
-    let current_val = pwasm_ethereum::read(&H256(TEST_KERNEL_SYSCALL_TOGGLE_PTR));
+    // We need to determine if this is a syscall or not. Because call_code
+    // is not correctly implemented we need to think about this a little.
+    // Because only delegate call is ever used, we can't use a sender
+    // address.
 
-    // TODO: Remove Toggling and replace current Kernel Interface with Standard Entry Procedure Interface
-    // See issue #181
-    // If Toggled Run Entry Procedure
-    // Once the entry procedure is toggled on, there is no existing mechanism to
-    // turn it off.
-    if current_val[0] == 1 {
-        // We need to determine if this is a syscall or not. Because call_code
-        // is not correctly implemented we need to think about this a little.
-        // Because only delegate call is ever used, we can't use a sender
-        // address.
+    // If the current procedure is set to a non-zero value, we know we are
+    // mid execution. Therefore this must be a system call.
+    let current_proc = proc_table::get_current_proc_id();
+    if current_proc == [0; 24] {
+        // We are starting the kernel, therefore we should execute the entry
+        // procedure.
+        let proc_id: ProcedureKey = proc_table::get_entry_proc_id();
+        let entry_address = proc_table::get_proc_addr(proc_id).expect("No Entry Proc");
 
-        // If the first byte is 0x00, it is not a valid syscall. Therefore we
-        // will interpret it as "toggle test mode".
-        if pwasm_ethereum::input()[0] == 0x00 {
-            kernel::toggle_syscall();
-        }
-
-        // If the current procedure is set to a non-zero value, we know we are
-        // mid execution. Therefore this must be a system call.
-        let current_proc = proc_table::get_current_proc_id();
-        if current_proc == [0; 24] {
-            // We are starting the kernel, therefore we should execute the entry
-            // procedure.
-            let proc_id: ProcedureKey = proc_table::get_entry_proc_id();
-            let entry_address = proc_table::get_proc_addr(proc_id).expect("No Entry Proc");
-
-            // Save the procedure we are about to call into "current procedure"
-            proc_table::set_current_proc_id(proc_id).unwrap();
-            // We need to subtract some gas from the limit, because there will
-            // be instructions in-between that need to be run.
-            actual_call_code(pwasm_ethereum::gas_left()-10000, &entry_address, U256::zero(), &pwasm_ethereum::input(), &mut Vec::new()).expect("Invalid Entry Proc");
-            // Unset the current procedure
-            proc_table::set_current_proc_id([0; 24]).unwrap();
-            pwasm_ethereum::ret(&result());
-        } else {
-            // We are currently executing the procedure identified by
-            // 'current_proc', therefore we should interpret this as a system
-            // call.
-
-            // Put the input into a cursor for deserialization.
-            let input_slice = pwasm_ethereum::input();
-            let mut input = Cursor::new(input_slice.as_slice());
-            // Attempt to deserialize the input into a syscall. Panic on
-            // deserialization failure.
-            let syscall: SysCall = SysCall::deserialize(&mut input).unwrap();
-            // Check the relevant cap for this procedure and the given syscall.
-            let cap_ok = syscall.check_cap();
-            // If the cap is ok, execute the syscall.
-            if cap_ok {
-                syscall.execute();
-            } else {
-                panic!("Bad Cap");
-                // TODO: implement revert
-                // pwasm_ethereum::ret(&[]);
-            }
-            pwasm_ethereum::ret(&result());
-        }
-
+        // Save the procedure we are about to call into "current procedure"
+        proc_table::set_current_proc_id(proc_id).unwrap();
+        // We need to subtract some gas from the limit, because there will
+        // be instructions in-between that need to be run.
+        actual_call_code(pwasm_ethereum::gas_left()-10000, &entry_address, U256::zero(), &pwasm_ethereum::input(), &mut Vec::new()).expect("Invalid Entry Proc");
+        // Unset the current procedure
+        proc_table::set_current_proc_id([0; 24]).unwrap();
+        pwasm_ethereum::ret(&result());
     } else {
-        // If not toggled expose test interface
-        let mut endpoint = kernel::TestKernelEndpoint::new(kernel::KernelContract {});
-        // Read http://solidity.readthedocs.io/en/develop/abi-spec.html#formal-specification-of-the-encoding for details
-        pwasm_ethereum::ret(&endpoint.dispatch(&pwasm_ethereum::input()));
+        // We are currently executing the procedure identified by
+        // 'current_proc', therefore we should interpret this as a system
+        // call.
+
+        // Put the input into a cursor for deserialization.
+        let input_slice = pwasm_ethereum::input();
+        let mut input = Cursor::new(input_slice.as_slice());
+        // Attempt to deserialize the input into a syscall. Panic on
+        // deserialization failure.
+        let syscall: SysCall = SysCall::deserialize(&mut input).unwrap();
+        // Check the relevant cap for this procedure and the given syscall.
+        let cap_ok = syscall.check_cap();
+        // If the cap is ok, execute the syscall.
+        if cap_ok {
+            syscall.execute();
+        } else {
+            panic!("Bad Cap");
+            // TODO: implement revert
+            // pwasm_ethereum::ret(&[]);
+        }
+        pwasm_ethereum::ret(&result());
     }
 }
 

--- a/kernel-ewasm/cap9-std/Cargo.toml
+++ b/kernel-ewasm/cap9-std/Cargo.toml
@@ -12,6 +12,8 @@ cap9-core = {path = "../cap9-core", default-features = false}
 
 [dev-dependencies]
 pwasm-abi-derive = { git = "https://github.com/Daohub-io/pwasm-abi.git", branch = "json-payable-constructors" }
+validator = { path = "../validator", default-features = false }
+parity-wasm = { git = "https://github.com/paritytech/parity-wasm.git", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cap9-test = { path = "../cap9-test" }

--- a/kernel-ewasm/cap9-std/examples/validator_test.rs
+++ b/kernel-ewasm/cap9-std/examples/validator_test.rs
@@ -1,0 +1,116 @@
+#![no_std]
+#![allow(non_snake_case)]
+
+extern crate pwasm_std;
+extern crate pwasm_abi;
+extern crate pwasm_abi_derive;
+extern crate pwasm_ethereum;
+extern crate parity_wasm;
+extern crate validator;
+extern crate cap9_std;
+
+use pwasm_abi::types::*;
+
+use cap9_std::proc_table;
+use cap9_std::*;
+use cap9_std::syscalls::SysCall;
+
+use cap9_core::{Cursor, Deserialize};
+
+// When we are compiling to WASM, unresolved references are left as (import)
+// expressions. However, under any other target symbols will have to be linked
+// for EVM functions (blocknumber, create, etc.). Therefore, when we are not
+// compiling for WASM (be it test, realse, whatever) we want to link in dummy
+// functions. pwasm_test provides all the builtins provided by parity, while
+// cap9_test covers the few that we have implemented ourselves.
+
+fn main() {}
+
+pub mod entry {
+    use pwasm_abi::types::*;
+    use pwasm_ethereum;
+    use pwasm_abi_derive::eth_abi;
+    use cap9_std;
+
+    use validator::{Validity, Module};
+
+    #[eth_abi(TestValidatorEndpoint)]
+    pub trait TestValidatorInterface {
+        /// The constructor set with Initial Entry Procedure
+        fn constructor(&mut self);
+
+        /// Get Number
+        #[constant]
+        fn getNum(&mut self) -> U256;
+
+        fn callExternal(&mut self, cap_idx: U256, address: Address, value: U256, payload: Vec<u8>);
+
+        /// Check if Procedure Contract is Valid
+        fn check_contract(&mut self, _to: Address) -> bool;
+        /// Get the size (in bytes) of another contract
+        fn get_code_size(&mut self, _to: Address) -> i32;
+        /// Copy the code of another contract into memory
+        fn code_copy(&mut self, _to: Address) -> pwasm_std::Vec<u8>;
+    }
+
+    pub struct ValidatorContract;
+
+    impl TestValidatorInterface for ValidatorContract {
+
+        fn constructor(&mut self) {}
+
+        fn getNum(&mut self) -> U256 {
+            U256::from(6)
+        }
+
+        fn callExternal(&mut self, cap_idx: U256, address: Address, value: U256, payload: Vec<u8>) {
+            cap9_std::acc_call(cap_idx.as_u32() as u8, address, value, payload).unwrap();
+            pwasm_ethereum::ret(&cap9_std::result());
+        }
+
+        fn check_contract(&mut self, target: Address) -> bool {
+            // First we check if the target is the null address. If so we return
+            // false.
+            if target == H160::zero() {
+                false
+            } else {
+                // Next we get the code of the contract, using EXTCODECOPY under
+                // the hood.
+                let code: pwasm_std::Vec<u8> = self.code_copy(target);
+                Module::new(code.as_slice()).is_valid()
+            }
+        }
+
+        fn get_code_size(&mut self, to: Address) -> i32 {
+            super::extcodesize(&to)
+        }
+
+        fn code_copy(&mut self, to: Address) -> pwasm_std::Vec<u8> {
+            let mut code = super::extcodecopy(&to);
+            // TODO: FIXME: This is an awful hack. Without these two resize
+            // lines (which have no net effect) we hit an Unreachable trap in
+            // the WASM code. Jake's hypothesis is that these two lines trigger
+            // a reallocation of some kind (of the vector) that side-steps
+            // whatever issue is occuring.
+            code.resize(code.len()-1,0);
+            code.resize(code.len()+1,0);
+            code
+        }
+
+    }
+}
+// Declares the dispatch and dispatch_ctor methods
+use pwasm_abi::eth::EndpointInterface;
+
+#[no_mangle]
+pub fn call() {
+    let mut endpoint = entry::TestValidatorEndpoint::new(entry::ValidatorContract {});
+    // Read http://solidity.readthedocs.io/en/develop/abi-spec.html#formal-specification-of-the-encoding for details
+    pwasm_ethereum::ret(&endpoint.dispatch(&pwasm_ethereum::input()));
+}
+
+#[no_mangle]
+pub fn deploy() {
+    let mut endpoint = entry::TestValidatorEndpoint::new(entry::ValidatorContract {});
+    endpoint.dispatch_ctor(&pwasm_ethereum::input());
+}

--- a/kernel-ewasm/cap9-std/src/proc_table/mod.rs
+++ b/kernel-ewasm/cap9-std/src/proc_table/mod.rs
@@ -19,11 +19,11 @@ const KERNEL_ADDRESS_PTR: [u8; 32] = [
     0xff, 0xff, 0xff, 0xff, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0,
 ];
-const KERNEL_CURRENT_PROC_PTR: [u8; 32] = [
+pub const KERNEL_CURRENT_PROC_PTR: [u8; 32] = [
     0xff, 0xff, 0xff, 0xff, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0,
 ];
-const KERNEL_ENTRY_PROC_PTR: [u8; 32] = [
+pub const KERNEL_ENTRY_PROC_PTR: [u8; 32] = [
     0xff, 0xff, 0xff, 0xff, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0,
 ];

--- a/kernel-ewasm/scripts/build.sh
+++ b/kernel-ewasm/scripts/build.sh
@@ -36,6 +36,7 @@ function build_procedure {
     wasm-build --target=wasm32-unknown-unknown ./target $1
 }
 
+build_procedure validator_test
 build_procedure writer_test
 build_procedure entry_test
 build_procedure caller_test

--- a/kernel-ewasm/tests/syscalls/log.ts
+++ b/kernel-ewasm/tests/syscalls/log.ts
@@ -83,15 +83,6 @@ async function logCapTest(capTopics, logTopics, data, result: boolean) {
     let kernel_asLogger = newProc.clone();
     kernel_asLogger.address = kernel.contract.address;
 
-    // The logger_test procedure is now set as the entry procedure. In
-    // order to execute this procedure, we first have to put the kernel
-    // into "entry procedure mode".
-    const toggle1 = await kernel.contract.methods.get_mode().call();
-    assert.strictEqual(toggle1, 0, "The kernel should be in test mode (0)");
-    await kernel.contract.methods.toggle_syscall().send();
-    // Once we have toggled entry procedure on, we have no way to switch
-    // back.
-
     // This is the index of the capability (in the procedures capability
     // list) that we will be using to perform the writes.
     const cap_index = 0;

--- a/kernel-ewasm/tests/syscalls/procedure_call.ts
+++ b/kernel-ewasm/tests/syscalls/procedure_call.ts
@@ -22,15 +22,6 @@ describe('Procedure Call Syscall', function () {
             let kernel_asCaller = newProc.clone();
             kernel_asCaller.address = kernel.contract.address;
 
-            // The caller_test procedure is now set as the entry procedure. In
-            // order to execute this procedure, we first have to put the kernel
-            // into "entry procedure mode".
-            const toggle1 = await kernel.contract.methods.get_mode().call();
-            assert.strictEqual(toggle1, 0, "The kernel should be in test mode (0)");
-            await kernel.contract.methods.toggle_syscall().send();
-            // Once we have toggled entry procedure on, we have no way to switch
-            // back.
-
             // Retrieve the test value.
             const test_value = await kernel_asCaller.methods.testNum().call();
             assert.strictEqual(test_value.toNumber(), 76, "The test value should be 76");
@@ -47,15 +38,6 @@ describe('Procedure Call Syscall', function () {
             // the writer contract directly to the kernel.
             let kernel_asCaller = newProc.clone();
             kernel_asCaller.address = kernel.contract.address;
-
-            // The caller_test procedure is now set as the entry procedure. In
-            // order to execute this procedure, we first have to put the kernel
-            // into "entry procedure mode".
-            const toggle1 = await kernel.contract.methods.get_mode().call();
-            assert.strictEqual(toggle1, 0, "The kernel should be in test mode (0)");
-            await kernel.contract.methods.toggle_syscall().send();
-            // Once we have toggled entry procedure on, we have no way to switch
-            // back.
 
             // This is the key that we will be modifying in storage.
             const key = "0x" + web3.utils.fromAscii("init",24).slice(2).padStart(64,"0");
@@ -86,15 +68,6 @@ describe('Procedure Call Syscall', function () {
             // the writer contract directly to the kernel.
             let kernel_asCaller = newProc.clone();
             kernel_asCaller.address = kernel.contract.address;
-
-            // The caller_test procedure is now set as the entry procedure. In
-            // order to execute this procedure, we first have to put the kernel
-            // into "entry procedure mode".
-            const toggle1 = await kernel.contract.methods.get_mode().call();
-            assert.strictEqual(toggle1, 0, "The kernel should be in test mode (0)");
-            await kernel.contract.methods.toggle_syscall().send();
-            // Once we have toggled entry procedure on, we have no way to switch
-            // back.
 
             // This is the key that we will be modifying in storage.
             const key = "0x" + web3.utils.fromAscii("init",24).slice(2).padStart(64,"0");

--- a/kernel-ewasm/tests/syscalls/register.ts
+++ b/kernel-ewasm/tests/syscalls/register.ts
@@ -744,14 +744,6 @@ async function registerTest(registerCaps, requestedCaps, procName, contractName,
     // the writer contract directly to the kernel.
     let kernel_asRegister = newProc.clone();
     kernel_asRegister.address = kernel.contract.address;
-    // The register_test procedure is now set as the entry procedure. In
-    // order to execute this procedure, we first have to put the kernel
-    // into "entry procedure mode".
-    const toggle1 = await kernel.contract.methods.get_mode().call();
-    assert.strictEqual(toggle1, 0, "The kernel should be in test mode (0)");
-    await kernel.contract.methods.toggle_syscall().send();
-    // Once we have toggled entry procedure on, we have no way to switch
-    // back.
 
     // This is the key of the procedure that we will be registering.
     const key = "0x" + web3.utils.fromAscii(procName, 24).slice(2).padStart(64, "0");

--- a/kernel-ewasm/tests/syscalls/write.ts
+++ b/kernel-ewasm/tests/syscalls/write.ts
@@ -22,15 +22,6 @@ describe('Write Syscall', function () {
             let kernel_asWriter = newProc.clone();
             kernel_asWriter.address = kernel.contract.address;
 
-            // The writer_test procedure is now set as the entry procedure. In
-            // order to execute this procedure, we first have to put the kernel
-            // into "entry procedure mode".
-            const toggle1 = await kernel.contract.methods.get_mode().call();
-            assert.strictEqual(toggle1, 0, "The kernel should be in test mode (0)");
-            await kernel.contract.methods.toggle_syscall().send();
-            // Once we have toggled entry procedure on, we have no way to switch
-            // back.
-
             // This is the key that we will be modifying in storage.
             const key = "0xdeadbeef";
 
@@ -50,15 +41,6 @@ describe('Write Syscall', function () {
             // the writer contract directly to the kernel.
             let kernel_asWriter = newProc.clone();
             kernel_asWriter.address = kernel.contract.address;
-
-            // The writer_test procedure is now set as the entry procedure. In
-            // order to execute this procedure, we first have to put the kernel
-            // into "entry procedure mode".
-            const toggle1 = await kernel.contract.methods.get_mode().call();
-            assert.strictEqual(toggle1, 0, "The kernel should be in test mode (0)");
-            await kernel.contract.methods.toggle_syscall().send();
-            // Once we have toggled entry procedure on, we have no way to switch
-            // back.
 
             // This is the key that we will be modifying in storage.
             const key = "0xdeadbeef";
@@ -92,15 +74,6 @@ describe('Write Syscall', function () {
             // the writer contract directly to the kernel.
             let kernel_asWriter = newProc.clone();
             kernel_asWriter.address = kernel.contract.address;
-
-            // The writer_test procedure is now set as the entry procedure. In
-            // order to execute this procedure, we first have to put the kernel
-            // into "entry procedure mode".
-            const toggle1 = await kernel.contract.methods.get_mode().call();
-            assert.strictEqual(toggle1, 0, "The kernel should be in test mode (0)");
-            await kernel.contract.methods.toggle_syscall().send();
-            // Once we have toggled entry procedure on, we have no way to switch
-            // back.
 
             // This is the key that we will be modifying in storage.
             const key = "0xdeadbeef";
@@ -138,15 +111,6 @@ describe('Write Syscall', function () {
             // the writer contract directly to the kernel.
             let kernel_asWriter = newProc.clone();
             kernel_asWriter.address = kernel.contract.address;
-
-            // The writer_test procedure is now set as the entry procedure. In
-            // order to execute this procedure, we first have to put the kernel
-            // into "entry procedure mode".
-            const toggle1 = await kernel.contract.methods.get_mode().call();
-            assert.strictEqual(toggle1, 0, "The kernel should be in test mode (0)");
-            await kernel.contract.methods.toggle_syscall().send();
-            // Once we have toggled entry procedure on, we have no way to switch
-            // back.
 
             // This is the key that we will be modifying in storage.
             const key = "0xdeadbeef";

--- a/kernel-ewasm/tests/utils/tester.ts
+++ b/kernel-ewasm/tests/utils/tester.ts
@@ -63,11 +63,6 @@ export class Tester {
         // the writer contract directly to the kernel.
         this.interface = firstEntry.clone();
         this.interface.address = this.kernel.contract.address;
-        // In order to execute procedures, we first have to put the kernel into
-        // "entry procedure mode".
-        const toggle1 = await this.kernel.contract.methods.get_mode().call();
-        assert.strictEqual(toggle1, 0, "The kernel should be in test mode (0)");
-        await this.kernel.contract.methods.toggle_syscall().send();
     }
 
     // Register a procedure. This assumes the current entry procedure for the


### PR DESCRIPTION
The kernel contains a test interface which is marked to be removed. Removing this simplifies the kernel and removes direct access to kernel internals which bypasses the capability system.